### PR TITLE
Fix download quality selection to use correct bitrate codes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1332,7 +1332,7 @@
             }
         },
         
-        getSongUrl: (song, quality = "320000") => {
+        getSongUrl: (song, quality = "320") => {
             const signature = API.generateSignature();
             return `${API.baseUrl}?types=url&id=${song.id}&source=${song.source || "netease"}&br=${quality}&s=${signature}`;
         },
@@ -1724,10 +1724,10 @@
                     <button class="action-btn download" onclick="showQualityMenu(event, ${index}, 'search')" title="下载">
                         <i class="fas fa-download"></i>
                         <div class="quality-menu">
-                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '128000')">标准音质 (128k)</div>
-                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '192000')">高音质 (192k)</div>
-                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '320000')">超高音质 (320k)</div>
-                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '999000')">无损音质</div>
+                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '128')">标准音质 (128k)</div>
+                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '192')">高音质 (192k)</div>
+                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '320')">超高音质 (320k)</div>
+                            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, 'search', '999')">无损音质</div>
                         </div>
                     </button>
                 </div>
@@ -1761,10 +1761,10 @@
         const menu = document.createElement("div");
         menu.className = "dynamic-quality-menu";
         menu.innerHTML = `
-            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '128000')">标准音质 (128k)</div>
-            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '192000')">高音质 (192k)</div>
-            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '320000')">超高音质 (320k)</div>
-            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '999000')">无损音质</div>
+            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '128')">标准音质 (128k)</div>
+            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '192')">高音质 (192k)</div>
+            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '320')">超高音质 (320k)</div>
+            <div class="quality-option" onclick="downloadWithQuality(event, ${index}, '${type}', '999')">无损音质</div>
         `;
         
         // 设置菜单位置
@@ -2268,42 +2268,57 @@
     // 新增：滚动到当前歌词 - 修复居中显示问题
     function scrollToCurrentLyric(element) {
         const container = dom.lyrics;
-        const elementTop = element.offsetTop;
-        const elementHeight = element.offsetHeight;
         const containerHeight = container.clientHeight;
-        const containerScrollTop = container.scrollTop;
-        
-        // 计算元素相对于容器顶部的位置
-        const elementRelativeTop = elementTop - containerScrollTop;
-        
-        // 计算让当前歌词居中的滚动位置
-        // 目标：让元素的中心位置对齐到容器的中心位置
-        const targetScrollTop = elementTop - (containerHeight / 2) + (elementHeight / 2);
-        
-        // 确保滚动位置不会超出边界
+        const elementRect = element.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+
+        // 计算元素在容器内部的可视位置，避免受到 offsetParent 影响
+        const elementOffsetTop = elementRect.top - containerRect.top + container.scrollTop;
+        const elementHeight = elementRect.height;
+
+        // 目标滚动位置：让当前歌词的中心与容器中心对齐
+        const targetScrollTop = elementOffsetTop - (containerHeight / 2) + (elementHeight / 2);
+
         const maxScrollTop = container.scrollHeight - containerHeight;
         const finalScrollTop = Math.max(0, Math.min(targetScrollTop, maxScrollTop));
-        
-        container.scrollTo({
-            top: finalScrollTop,
-            behavior: 'smooth'
-        });
-        
-        debugLog(`歌词滚动: 元素位置=${elementTop}, 容器高度=${containerHeight}, 目标滚动=${finalScrollTop}`);
+
+        if (Math.abs(container.scrollTop - finalScrollTop) > 1) {
+            container.scrollTo({
+                top: finalScrollTop,
+                behavior: 'smooth'
+            });
+        }
+
+        debugLog(`歌词滚动: 元素在容器内偏移=${elementOffsetTop}, 容器高度=${containerHeight}, 目标滚动=${finalScrollTop}`);
     }
 
     // 修复：下载歌曲
-    async function downloadSong(song, quality = "320000") {
+    async function downloadSong(song, quality = "320") {
         try {
             showNotification("正在准备下载...");
-            
+
             const audioUrl = API.getSongUrl(song, quality);
             const audioData = await API.jsonpRequest(audioUrl);
-            
+
             if (audioData && audioData.url) {
                 const link = document.createElement("a");
                 link.href = audioData.url;
-                link.download = `${song.name} - ${Array.isArray(song.artist) ? song.artist.join(", ") : song.artist}.mp3`;
+                const preferredExtension =
+                    quality === "999" ? "flac" : quality === "740" ? "ape" : "mp3";
+                const fileExtension = (() => {
+                    try {
+                        const url = new URL(audioData.url);
+                        const pathname = url.pathname || "";
+                        const match = pathname.match(/\.([a-z0-9]+)$/i);
+                        if (match) {
+                            return match[1];
+                        }
+                    } catch (error) {
+                        console.warn("无法从下载链接中解析扩展名:", error);
+                    }
+                    return preferredExtension;
+                })();
+                link.download = `${song.name} - ${Array.isArray(song.artist) ? song.artist.join(", ") : song.artist}.${fileExtension}`;
                 link.target = "_blank";
                 document.body.appendChild(link);
                 link.click();


### PR DESCRIPTION
## Summary
- send documented bitrate codes when building download quality options
- default API URL generation to 320 kbps and infer download file extension from the returned link
- preserve lossless downloads only when explicitly requested

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68e208cb4ddc832b90db35d97e740ccd