### PR TITLE
Persist playlist state in localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1247,6 +1247,52 @@
         debugInfo: document.getElementById("debugInfo"),
         playModeBtn: document.getElementById("playModeBtn"),
     };
+
+    function safeGetLocalStorage(key) {
+        try {
+            return localStorage.getItem(key);
+        } catch (error) {
+            console.warn(`读取本地存储失败: ${key}`, error);
+            return null;
+        }
+    }
+
+    function safeSetLocalStorage(key, value) {
+        try {
+            localStorage.setItem(key, value);
+        } catch (error) {
+            console.warn(`写入本地存储失败: ${key}`, error);
+        }
+    }
+
+    function parseJSON(value, fallback) {
+        if (!value) return fallback;
+        try {
+            const parsed = JSON.parse(value);
+            return parsed;
+        } catch (error) {
+            console.warn("解析本地存储 JSON 失败", error);
+            return fallback;
+        }
+    }
+
+    const savedPlaylistSongs = (() => {
+        const stored = safeGetLocalStorage("playlistSongs");
+        const playlist = parseJSON(stored, []);
+        return Array.isArray(playlist) ? playlist : [];
+    })();
+
+    const savedCurrentTrackIndex = (() => {
+        const stored = safeGetLocalStorage("currentTrackIndex");
+        const index = Number.parseInt(stored, 10);
+        return Number.isInteger(index) ? index : -1;
+    })();
+
+    const savedPlayMode = (() => {
+        const stored = safeGetLocalStorage("playMode");
+        const modes = ["list", "single", "random"];
+        return modes.includes(stored) ? stored : "list";
+    })();
     
     // API配置 - 修复API地址和请求方式
     const API = {
@@ -1351,7 +1397,7 @@
     const state = {
         onlineSongs: [],
         searchResults: [],
-        currentTrackIndex: -1,
+        currentTrackIndex: savedCurrentTrackIndex,
         currentAudioUrl: null,
         lyricsData: [],
         currentLyricLine: -1,
@@ -1363,11 +1409,17 @@
         currentSong: null,
         debugMode: false,
         isSearchMode: false, // 新增：搜索模式状态
-        playlistSongs: [], // 新增：统一播放列表
-        playMode: "list", // 新增：播放模式 'list', 'single', 'random'
+        playlistSongs: savedPlaylistSongs, // 新增：统一播放列表
+        playMode: savedPlayMode, // 新增：播放模式 'list', 'single', 'random'
         userScrolledLyrics: false, // 新增：用户是否手动滚动歌词
         lyricsScrollTimeout: null, // 新增：歌词滚动超时
     };
+
+    function savePlayerState() {
+        safeSetLocalStorage("playlistSongs", JSON.stringify(state.playlistSongs));
+        safeSetLocalStorage("currentTrackIndex", String(state.currentTrackIndex));
+        safeSetLocalStorage("playMode", state.playMode);
+    }
 
     // 调试日志函数
     function debugLog(message) {
@@ -1418,28 +1470,36 @@
         dom.searchResults.innerHTML = "";
     }
 
+    const playModeTexts = {
+        "list": "列表循环",
+        "single": "单曲循环",
+        "random": "随机播放"
+    };
+
+    const playModeIcons = {
+        "list": "fa-repeat",
+        "single": "fa-redo",
+        "random": "fa-shuffle"
+    };
+
+    function updatePlayModeUI() {
+        const mode = state.playMode;
+        dom.playModeBtn.innerHTML = `<i class="fas ${playModeIcons[mode] || playModeIcons.list}"></i>`;
+        dom.playModeBtn.title = `播放模式: ${playModeTexts[mode] || playModeTexts.list}`;
+    }
+
     // 新增：播放模式切换
     function togglePlayMode() {
         const modes = ["list", "single", "random"];
         const currentIndex = modes.indexOf(state.playMode);
         const nextIndex = (currentIndex + 1) % modes.length;
         state.playMode = modes[nextIndex];
-        
-        const modeTexts = {
-            "list": "列表循环",
-            "single": "单曲循环", 
-            "random": "随机播放"
-        };
-        
-        const modeIcons = {
-            "list": "fa-repeat",
-            "single": "fa-redo",
-            "random": "fa-shuffle"
-        };
-        
-        dom.playModeBtn.innerHTML = `<i class="fas ${modeIcons[state.playMode]}"></i>`;
-        dom.playModeBtn.title = `播放模式: ${modeTexts[state.playMode]}`;
-        showNotification(`播放模式: ${modeTexts[state.playMode]}`);
+
+        updatePlayModeUI();
+        savePlayerState();
+
+        const modeText = playModeTexts[state.playMode] || playModeTexts.list;
+        showNotification(`播放模式: ${modeText}`);
         debugLog(`播放模式切换为: ${state.playMode}`);
     }
 
@@ -1448,7 +1508,7 @@
     dom.audioPlayer.addEventListener("timeupdate", syncLyrics);
 
     function setupInteractions() {
-        const savedTheme = localStorage.getItem("theme");
+        const savedTheme = safeGetLocalStorage("theme");
         if (savedTheme) {
             document.body.classList.toggle("dark-mode", savedTheme === "dark");
             dom.themeToggle.checked = savedTheme === "dark";
@@ -1456,15 +1516,16 @@
         dom.themeToggle.addEventListener("change", (e) => {
             const isDark = e.target.checked;
             document.body.classList.toggle("dark-mode", isDark);
-            localStorage.setItem("theme", isDark ? "dark" : "light");
+            safeSetLocalStorage("theme", isDark ? "dark" : "light");
         });
 
         dom.loadOnlineBtn.addEventListener("click", exploreOnlineMusic);
-        
+
         dom.showPlaylistBtn.addEventListener("click", () => switchMobileView("playlist"));
         dom.showLyricsBtn.addEventListener("click", () => switchMobileView("lyrics"));
-        
+
         // 播放模式按钮事件
+        updatePlayModeUI();
         dom.playModeBtn.addEventListener("click", togglePlayMode);
         
         // 搜索相关事件 - 修复搜索下拉框显示问题
@@ -1497,7 +1558,7 @@
         document.addEventListener("click", (e) => {
             const qualityMenus = document.querySelectorAll(".quality-menu");
             qualityMenus.forEach(menu => {
-                if (!menu.contains(e.target) && 
+                if (!menu.contains(e.target) &&
                     !e.target.closest(".playlist-item-download")) {
                     menu.classList.remove("show");
                     const parentItem = menu.closest(".search-result-item");
@@ -1548,6 +1609,35 @@
                 }
             }, 3000);
         });
+
+        if (state.playlistSongs.length > 0) {
+            let restoredIndex = state.currentTrackIndex;
+            if (restoredIndex < 0 || restoredIndex >= state.playlistSongs.length) {
+                restoredIndex = 0;
+                state.currentTrackIndex = restoredIndex;
+            }
+
+            state.currentPlaylist = "playlist";
+            renderPlaylist();
+
+            const restoredSong = state.playlistSongs[restoredIndex];
+            if (restoredSong) {
+                state.currentSong = restoredSong;
+                updatePlaylistHighlight();
+                updateCurrentSongInfo(restoredSong).catch(error => {
+                    console.error("恢复歌曲信息失败:", error);
+                });
+            }
+
+            dom.audioPlayer.pause();
+            dom.audioPlayer.src = "";
+            dom.audioPlayer.currentTime = 0;
+            state.currentAudioUrl = null;
+
+            savePlayerState();
+        } else {
+            dom.playlist.classList.add("empty");
+        }
     }
 
     // 修复：更新当前歌曲信息和封面
@@ -1866,7 +1956,7 @@
     // 新增：渲染统一播放列表
     function renderPlaylist() {
         dom.playlist.classList.remove("empty");
-        const playlistHtml = state.playlistSongs.map((song, index) => 
+        const playlistHtml = state.playlistSongs.map((song, index) =>
             `<div onclick="playPlaylistSong(${index})" data-index="${index}">
                 ${song.name} - ${Array.isArray(song.artist) ? song.artist.join(", ") : song.artist}
                 <button class="playlist-item-remove" onclick="event.stopPropagation(); removeFromPlaylist(${index})" title="从播放列表移除">
@@ -1884,7 +1974,8 @@
         if (clearBtn && state.playlistSongs.length > 0) {
             dom.playlist.appendChild(clearBtn);
         }
-        
+
+        savePlayerState();
         updatePlaylistHighlight();
     }
 
@@ -1927,7 +2018,8 @@
         } else {
             renderPlaylist();
         }
-        
+
+        savePlayerState();
         showNotification("已从播放列表移除", "success");
     }
 
@@ -1958,7 +2050,8 @@
         dom.playlist.innerHTML = `<button class="clear-playlist-btn" id="clearPlaylistBtn" onclick="clearPlaylist()" title="清空播放列表">
             <i class="fas fa-trash"></i>
         </button>`;
-        
+
+        savePlayerState();
         showNotification("播放列表已清空", "success");
     }
 
@@ -2027,6 +2120,8 @@
         } catch (error) {
             console.error("播放歌曲失败:", error);
             showNotification("播放失败，请稍后重试", "error");
+        } finally {
+            savePlayerState();
         }
     }
 


### PR DESCRIPTION
## Summary
- add safe localStorage helpers and hydrate the player state from persisted playlist and mode values
- restore the saved playlist and song details on load while keeping playback paused until the user resumes
- persist playlist and mode updates whenever the queue changes or playback mode toggles

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68e20d47ebdc832bb92d8ecbe8a8626b