### PR TITLE
Add configurable playback quality selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -729,15 +729,67 @@
             padding: 0 25px; 
             gap: 10px; 
         }
-        .controls button:disabled { 
-            background: var(--text-secondary-color); 
-            cursor: not-allowed; 
-            transform: none; 
-            box-shadow: none; 
+        .controls button:disabled {
+            background: var(--text-secondary-color);
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
         }
-        .controls audio { 
-            flex-grow: 1; 
-            min-width: 300px; 
+        .controls audio {
+            flex-grow: 1;
+            min-width: 300px;
+        }
+
+        .quality-selector {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            background: var(--component-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 999px;
+            padding: 8px 16px;
+            box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+            transition: all 0.3s ease;
+            flex-shrink: 0;
+            min-width: 180px;
+        }
+
+        .quality-selector label {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.9em;
+            color: var(--text-secondary-color);
+            white-space: nowrap;
+        }
+
+        .quality-selector select {
+            border: none;
+            background: transparent;
+            color: var(--text-color);
+            font-size: 0.95em;
+            font-family: inherit;
+            cursor: pointer;
+            outline: none;
+            padding-right: 4px;
+        }
+
+        .quality-selector select option {
+            color: #2c3e50;
+        }
+
+        .dark-mode .quality-selector {
+            background: rgba(44, 44, 44, 0.6);
+            border-color: rgba(255, 255, 255, 0.1);
+            box-shadow: none;
+        }
+
+        .dark-mode .quality-selector select {
+            color: #ecf0f1;
+        }
+
+        .dark-mode .quality-selector select option {
+            color: #2c3e50;
         }
 
         /* 播放模式控制按钮 */
@@ -1210,6 +1262,15 @@
             </button>
         </div>
         <button onclick="playPrevious()" title="上一曲"><i class="fas fa-backward-step"></i></button>
+        <div class="quality-selector" title="选择播放音质">
+            <label for="qualitySelect"><i class="fas fa-wave-square"></i><span>音质</span></label>
+            <select id="qualitySelect">
+                <option value="128000">标准音质 (128k)</option>
+                <option value="192000">高音质 (192k)</option>
+                <option value="320000" selected>超高音质 (320k)</option>
+                <option value="999000">无损音质</option>
+            </select>
+        </div>
         <audio id="audioPlayer" controls></audio>
         <button onclick="playNext()" title="下一曲"><i class="fas fa-forward-step"></i></button>
         <button id="loadOnlineBtn" title="聚合所有雷达，探索新音乐">
@@ -1246,13 +1307,14 @@
         currentSongArtist: document.getElementById("currentSongArtist"),
         debugInfo: document.getElementById("debugInfo"),
         playModeBtn: document.getElementById("playModeBtn"),
+        qualitySelect: document.getElementById("qualitySelect"),
     };
     
     // API配置 - 修复API地址和请求方式
     const API = {
         name: "GD Studio API",
         baseUrl: "https://music-api.gdstudio.xyz/api.php",
-        
+
         generateSignature: () => {
             return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
         },
@@ -1348,6 +1410,15 @@
         }
     };
 
+    const QUALITY_OPTIONS = {
+        "128000": "标准音质 (128k)",
+        "192000": "高音质 (192k)",
+        "320000": "超高音质 (320k)",
+        "999000": "无损音质"
+    };
+
+    const QUALITY_DEFAULT = "320000";
+
     const state = {
         onlineSongs: [],
         searchResults: [],
@@ -1367,6 +1438,7 @@
         playMode: "list", // 新增：播放模式 'list', 'single', 'random'
         userScrolledLyrics: false, // 新增：用户是否手动滚动歌词
         lyricsScrollTimeout: null, // 新增：歌词滚动超时
+        playbackQuality: QUALITY_DEFAULT,
     };
 
     // 调试日志函数
@@ -1377,6 +1449,18 @@
             debugInfo.innerHTML += `<div>${new Date().toLocaleTimeString()}: ${message}</div>`;
             debugInfo.classList.add("show");
             debugInfo.scrollTop = debugInfo.scrollHeight;
+        }
+    }
+
+    function getQualityLabel(quality) {
+        return QUALITY_OPTIONS[quality] || quality;
+    }
+
+    function saveQualityPreference(quality) {
+        try {
+            localStorage.setItem("playbackQuality", quality);
+        } catch (error) {
+            console.warn("无法保存音质偏好:", error);
         }
     }
 
@@ -1443,6 +1527,49 @@
         debugLog(`播放模式切换为: ${state.playMode}`);
     }
 
+    async function handleQualityChange(event) {
+        const selectedQuality = event.target.value;
+
+        if (!selectedQuality || selectedQuality === state.playbackQuality) {
+            return;
+        }
+
+        const previousQuality = state.playbackQuality;
+        state.playbackQuality = selectedQuality;
+
+        const qualityLabel = getQualityLabel(selectedQuality);
+        debugLog(`尝试切换音质至: ${qualityLabel}`);
+
+        try {
+            let playbackResult = null;
+            if (state.currentSong) {
+                playbackResult = await loadAudioForSong(state.currentSong, { preservePosition: true });
+            }
+
+            saveQualityPreference(selectedQuality);
+
+            if (!state.currentSong) {
+                showNotification(`默认音质已设置为 ${qualityLabel}`, "success");
+            } else if (playbackResult && (!playbackResult.attemptedResume || playbackResult.resumeSucceeded)) {
+                showNotification(`音质已切换为 ${qualityLabel}`, "success");
+            } else if (playbackResult && playbackResult.attemptedResume && !playbackResult.resumeSucceeded) {
+                debugLog("音质切换后播放未自动恢复，可能需要用户交互");
+            } else {
+                showNotification(`音质已切换为 ${qualityLabel}`, "success");
+            }
+            debugLog(`音质切换成功: ${qualityLabel}`);
+        } catch (error) {
+            console.error("切换音质失败:", error);
+            state.playbackQuality = previousQuality;
+            if (dom.qualitySelect) {
+                dom.qualitySelect.value = previousQuality;
+            }
+            saveQualityPreference(previousQuality);
+            showNotification("音质切换失败，请稍后重试", "error");
+            debugLog("音质切换失败，已恢复之前的设置");
+        }
+    }
+
     window.addEventListener("load", setupInteractions);
     dom.audioPlayer.addEventListener("ended", autoPlayNext);
     dom.audioPlayer.addEventListener("timeupdate", syncLyrics);
@@ -1458,6 +1585,22 @@
             document.body.classList.toggle("dark-mode", isDark);
             localStorage.setItem("theme", isDark ? "dark" : "light");
         });
+
+        let savedQuality = null;
+        try {
+            savedQuality = localStorage.getItem("playbackQuality");
+        } catch (error) {
+            console.warn("无法读取音质偏好:", error);
+        }
+
+        if (savedQuality && QUALITY_OPTIONS[savedQuality]) {
+            state.playbackQuality = savedQuality;
+        }
+
+        if (dom.qualitySelect) {
+            dom.qualitySelect.value = state.playbackQuality;
+            dom.qualitySelect.addEventListener("change", handleQualityChange);
+        }
 
         dom.loadOnlineBtn.addEventListener("click", exploreOnlineMusic);
         
@@ -1965,11 +2108,11 @@
     // 新增：播放播放列表中的歌曲
     async function playPlaylistSong(index) {
         if (index < 0 || index >= state.playlistSongs.length) return;
-        
+
         const song = state.playlistSongs[index];
         state.currentTrackIndex = index;
         state.currentPlaylist = "playlist";
-        
+
         try {
             await playSong(song);
             updatePlaylistHighlight();
@@ -1991,38 +2134,92 @@
         });
     }
 
+    async function loadAudioForSong(song, { preservePosition = false } = {}) {
+        const audioPlayer = dom.audioPlayer;
+        const previousTime = preservePosition ? audioPlayer.currentTime : 0;
+        const wasPlaying = !audioPlayer.paused;
+        const shouldResume = preservePosition ? wasPlaying : true;
+        const qualityLabel = getQualityLabel(state.playbackQuality);
+
+        const audioUrl = API.getSongUrl(song, state.playbackQuality);
+        debugLog(`获取音频URL[${qualityLabel}]: ${audioUrl}`);
+
+        const audioData = await API.jsonpRequest(audioUrl);
+
+        if (audioData && audioData.url) {
+            state.currentAudioUrl = audioData.url;
+
+            return new Promise((resolve, reject) => {
+                const finish = (playbackSucceeded) => {
+                    resolve({
+                        attemptedResume: shouldResume,
+                        resumeSucceeded: !shouldResume || playbackSucceeded
+                    });
+                };
+
+                const handleLoadedMetadata = () => {
+                    audioPlayer.removeEventListener("error", handleError);
+
+                    if (preservePosition && previousTime > 0) {
+                        try {
+                            const safeTime = Math.min(previousTime, audioPlayer.duration || previousTime);
+                            audioPlayer.currentTime = safeTime;
+                            debugLog(`恢复播放进度到 ${safeTime.toFixed(2)} 秒`);
+                        } catch (seekError) {
+                            console.warn("无法恢复播放进度:", seekError);
+                        }
+                    }
+
+                    debugLog(`音频源加载完成（音质: ${qualityLabel}）`);
+
+                    if (shouldResume) {
+                        const playPromise = audioPlayer.play();
+                        if (playPromise !== undefined) {
+                            playPromise.then(() => finish(true)).catch(error => {
+                                console.error("播放失败:", error);
+                                showNotification("播放失败，请检查网络连接", "error");
+                                finish(false);
+                            });
+                        } else {
+                            finish(true);
+                        }
+                    } else {
+                        finish(false);
+                    }
+                };
+
+                const handleError = () => {
+                    audioPlayer.removeEventListener("loadedmetadata", handleLoadedMetadata);
+                    reject(new Error("音频加载失败"));
+                };
+
+                audioPlayer.addEventListener("loadedmetadata", handleLoadedMetadata, { once: true });
+                audioPlayer.addEventListener("error", handleError, { once: true });
+
+                audioPlayer.src = audioData.url;
+                audioPlayer.load();
+            });
+        }
+
+        throw new Error("无法获取音频播放地址");
+    }
+
     // 修复：播放歌曲函数 - 支持统一播放列表
     async function playSong(song) {
         try {
             // 更新当前歌曲信息和封面
             await updateCurrentSongInfo(song);
-            
-            // 获取音频URL
-            const audioUrl = API.getSongUrl(song);
-            debugLog(`获取音频URL: ${audioUrl}`);
-            
-            // 使用JSONP获取实际播放地址
-            const audioData = await API.jsonpRequest(audioUrl);
-            
-            if (audioData && audioData.url) {
-                state.currentAudioUrl = audioData.url;
-                dom.audioPlayer.src = audioData.url;
-                
-                // 尝试播放
-                const playPromise = dom.audioPlayer.play();
-                if (playPromise !== undefined) {
-                    playPromise.catch(error => {
-                        console.error("播放失败:", error);
-                        showNotification("播放失败，请检查网络连接", "error");
-                    });
-                }
-                
-                // 加载歌词
-                loadLyrics(song);
-                
-                debugLog(`开始播放: ${song.name}`);
+
+            // 加载并播放音频
+            const playbackResult = await loadAudioForSong(song);
+
+            // 加载歌词
+            loadLyrics(song);
+
+            if (playbackResult && playbackResult.attemptedResume && !playbackResult.resumeSucceeded) {
+                debugLog(`播放未能自动开始，等待用户手动播放: ${song.name}`);
             } else {
-                throw new Error("无法获取音频播放地址");
+                debugLog(`开始播放: ${song.name}（音质: ${getQualityLabel(state.playbackQuality)}）`);
             }
         } catch (error) {
             console.error("播放歌曲失败:", error);


### PR DESCRIPTION
## Summary
- add a playback quality selector to the controls and style it for both themes
- persist the user-selected bitrate in localStorage and restore it on load
- request audio streams with the chosen bitrate and smoothly reload the source when switching

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e20d491e50832bba97f9a08536b5cb