### PR TITLE
Clamp source dropdown width

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,7 @@
             border-radius: 12px;
             box-shadow: 0 12px 30px rgba(0,0,0,0.18);
             border: 1px solid var(--border-color);
+            box-sizing: border-box;
             min-width: 100%;
             max-height: 320px;
             overflow-y: auto;
@@ -2149,20 +2150,49 @@
 
         menu.classList.add("floating");
         menu.style.width = "auto";
-        menu.style.maxWidth = `${Math.max(0, viewportWidth - spacing * 2)}px`;
-        const minWidth = Math.min(Math.max(buttonRect.width, 160), Math.max(0, viewportWidth - spacing * 2));
-        menu.style.minWidth = `${minWidth}px`;
+        menu.style.minWidth = "";
+        menu.style.maxWidth = "";
+
+        const maxAvailableWidth = Math.max(0, viewportWidth - spacing * 2);
+        const naturalWidth = menu.scrollWidth;
+
+        const effectiveMaxWidth = maxAvailableWidth > 0
+            ? Math.min(maxAvailableWidth, 320)
+            : 320;
+
+        const baseWidth = Math.min(
+            Math.max(buttonRect.width, 160),
+            maxAvailableWidth > 0 ? maxAvailableWidth : Math.max(buttonRect.width, 160)
+        );
+
+        const targetWidth = Math.max(
+            baseWidth,
+            Math.min(naturalWidth, effectiveMaxWidth)
+        );
+
+        menu.style.width = `${targetWidth}px`;
+        menu.style.minWidth = `${baseWidth}px`;
+        menu.style.maxWidth = `${maxAvailableWidth > 0 ? effectiveMaxWidth : targetWidth}px`;
 
         const menuRect = menu.getBoundingClientRect();
         const menuWidth = menuRect.width;
         const menuHeight = menuRect.height;
 
-        let left = buttonRect.left;
-        if (left + menuWidth > viewportWidth - spacing) {
-            left = Math.max(spacing, viewportWidth - spacing - menuWidth);
-        }
-        if (left < spacing) {
-            left = spacing;
+        const buttonCenter = buttonRect.left + buttonRect.width / 2;
+        const minLeft = spacing;
+        const maxLeft = viewportWidth - spacing - menuWidth;
+
+        let left = buttonCenter - menuWidth / 2;
+
+        if (maxLeft >= minLeft) {
+            if (left < minLeft) {
+                left = Math.max(minLeft, Math.min(buttonRect.left, maxLeft));
+            }
+            if (left > maxLeft) {
+                left = Math.min(maxLeft, Math.max(buttonRect.right - menuWidth, minLeft));
+            }
+        } else {
+            left = Math.max(minLeft, buttonRect.left);
         }
 
         let top = buttonRect.bottom + spacing;


### PR DESCRIPTION
## Summary
- cap the floating source menu width to a reasonable size while respecting viewport constraints
- ensure the dropdown keeps the trigger button width as its minimum width to avoid overflow

## Testing
- No automated tests were run (static HTML page)

------
https://chatgpt.com/codex/tasks/task_b_68e28362bc54832b84d3011dce856176