### PR TITLE
Stabilize source dropdown animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,7 @@
             border-radius: 12px;
             box-shadow: 0 12px 30px rgba(0,0,0,0.18);
             border: 1px solid var(--border-color);
+            box-sizing: border-box;
             min-width: 100%;
             max-height: 320px;
             overflow-y: auto;
@@ -275,7 +276,7 @@
             opacity: 0;
             visibility: hidden;
             transform: translateY(-10px);
-            transition: all 0.2s ease;
+            transition: opacity 0.18s ease, transform 0.18s ease;
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
             z-index: 100000;
@@ -292,7 +293,7 @@
         .source-menu.floating {
             position: fixed;
             transform: translateY(0);
-            will-change: top, left;
+            will-change: opacity, transform;
         }
 
         .source-menu.floating:not(.show) {
@@ -2143,32 +2144,26 @@
 
         const menu = dom.sourceMenu;
         const buttonRect = dom.sourceSelectButton.getBoundingClientRect();
-        const viewportWidth = Math.max(window.innerWidth || 0, document.documentElement.clientWidth || 0);
         const viewportHeight = Math.max(window.innerHeight || 0, document.documentElement.clientHeight || 0);
-        const spacing = 12;
+        const spacing = 10;
 
         menu.classList.add("floating");
-        menu.style.width = "auto";
-        menu.style.maxWidth = `${Math.max(0, viewportWidth - spacing * 2)}px`;
-        const minWidth = Math.min(Math.max(buttonRect.width, 160), Math.max(0, viewportWidth - spacing * 2));
-        menu.style.minWidth = `${minWidth}px`;
+        const buttonWidth = Math.round(buttonRect.width);
+        const effectiveWidth = Math.max(buttonWidth, 0);
+
+        menu.style.width = `${effectiveWidth}px`;
+        menu.style.minWidth = `${effectiveWidth}px`;
+        menu.style.maxWidth = `${effectiveWidth}px`;
 
         const menuRect = menu.getBoundingClientRect();
-        const menuWidth = menuRect.width;
         const menuHeight = menuRect.height;
 
-        let left = buttonRect.left;
-        if (left + menuWidth > viewportWidth - spacing) {
-            left = Math.max(spacing, viewportWidth - spacing - menuWidth);
-        }
-        if (left < spacing) {
-            left = spacing;
-        }
+        let left = Math.round(buttonRect.left);
 
-        let top = buttonRect.bottom + spacing;
+        let top = Math.round(buttonRect.bottom + spacing);
         let openUpwards = false;
         if (top + menuHeight > viewportHeight - spacing) {
-            const upwardTop = buttonRect.top - spacing - menuHeight;
+            const upwardTop = Math.round(buttonRect.top - spacing - menuHeight);
             if (upwardTop >= spacing) {
                 top = upwardTop;
                 openUpwards = true;
@@ -2195,12 +2190,13 @@
 
     function openSourceMenu() {
         if (!dom.sourceMenu || !dom.sourceSelectButton) return;
+        state.sourceMenuOpen = true;
         buildSourceMenu();
         dom.sourceMenu.classList.add("floating");
+        updateSourceMenuPosition();
         dom.sourceMenu.classList.add("show");
         dom.sourceSelectButton.classList.add("active");
         dom.sourceSelectButton.setAttribute("aria-expanded", "true");
-        state.sourceMenuOpen = true;
         requestAnimationFrame(updateSourceMenuPosition);
     }
 


### PR DESCRIPTION
## Summary
- restrict the search source dropdown transition to opacity and translation so width and position changes apply instantly
- set the dropdown position before showing it to avoid the menu sliding in from the corner while opening

## Testing
- Not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_b_68e28362bc54832b84d3011dce856176