### PR TITLE
Add Cloudflare proxy and migrate API requests to fetch

### DIFF
--- a/functions/proxy.ts
+++ b/functions/proxy.ts
@@ -1,0 +1,135 @@
+const API_BASE_URL = "https://music-api.gdstudio.xyz/api.php";
+const KUWO_HOST_PATTERN = /(^|\.)kuwo\.cn$/i;
+const SAFE_RESPONSE_HEADERS = ["content-type", "cache-control", "accept-ranges", "content-length", "content-range", "etag", "last-modified", "expires"];
+
+function createCorsHeaders(init?: Headers): Headers {
+  const headers = new Headers();
+  if (init) {
+    for (const [key, value] of init.entries()) {
+      if (SAFE_RESPONSE_HEADERS.includes(key.toLowerCase())) {
+        headers.set(key, value);
+      }
+    }
+  }
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", "no-store");
+  }
+  headers.set("Access-Control-Allow-Origin", "*");
+  return headers;
+}
+
+function handleOptions(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}
+
+function isAllowedKuwoHost(hostname: string): boolean {
+  if (!hostname) return false;
+  return KUWO_HOST_PATTERN.test(hostname);
+}
+
+function normalizeKuwoUrl(rawUrl: string): URL | null {
+  try {
+    const parsed = new URL(rawUrl);
+    if (!isAllowedKuwoHost(parsed.hostname)) {
+      return null;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    parsed.protocol = "http:";
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function proxyKuwoAudio(targetUrl: string, request: Request): Promise<Response> {
+  const normalized = normalizeKuwoUrl(targetUrl);
+  if (!normalized) {
+    return new Response("Invalid target", { status: 400 });
+  }
+
+  const init: RequestInit = {
+    method: request.method,
+    headers: {
+      "User-Agent": request.headers.get("User-Agent") ?? "Mozilla/5.0",
+      "Referer": "https://www.kuwo.cn/",
+    },
+  };
+
+  const rangeHeader = request.headers.get("Range");
+  if (rangeHeader) {
+    (init.headers as Record<string, string>)["Range"] = rangeHeader;
+  }
+
+  const upstream = await fetch(normalized.toString(), init);
+  const headers = createCorsHeaders(upstream.headers);
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", "public, max-age=3600");
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}
+
+async function proxyApiRequest(url: URL, request: Request): Promise<Response> {
+  const apiUrl = new URL(API_BASE_URL);
+  url.searchParams.forEach((value, key) => {
+    if (key === "target" || key === "callback") {
+      return;
+    }
+    apiUrl.searchParams.set(key, value);
+  });
+
+  if (!apiUrl.searchParams.has("types")) {
+    return new Response("Missing types", { status: 400 });
+  }
+
+  const upstream = await fetch(apiUrl.toString(), {
+    headers: {
+      "User-Agent": request.headers.get("User-Agent") ?? "Mozilla/5.0",
+      "Accept": "application/json",
+    },
+  });
+
+  const headers = createCorsHeaders(upstream.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json; charset=utf-8");
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}
+
+export async function onRequest({ request }: { request: Request }): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return handleOptions();
+  }
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const url = new URL(request.url);
+  const target = url.searchParams.get("target");
+
+  if (target) {
+    return proxyKuwoAudio(target, request);
+  }
+
+  return proxyApiRequest(url, request);
+}

--- a/index.html
+++ b/index.html
@@ -1670,6 +1670,26 @@
         }
     }
 
+    function buildAudioProxyUrl(url) {
+        if (!url || typeof url !== "string") return url;
+
+        try {
+            const parsedUrl = new URL(url, window.location.href);
+            if (parsedUrl.protocol === "https:") {
+                return parsedUrl.toString();
+            }
+
+            if (parsedUrl.protocol === "http:" && /(^|\.)kuwo\.cn$/i.test(parsedUrl.hostname)) {
+                return `${API.baseUrl}?target=${encodeURIComponent(parsedUrl.toString())}`;
+            }
+
+            return parsedUrl.toString();
+        } catch (error) {
+            console.warn("无法解析音频地址，跳过代理", error);
+            return url;
+        }
+    }
+
     const SOURCE_OPTIONS = [
         { value: "netease", label: "网易云音乐" },
         { value: "kuwo", label: "酷我音乐" },
@@ -1747,47 +1767,46 @@
     // API配置 - 修复API地址和请求方式
     const API = {
         name: "GD Studio API",
-        baseUrl: "https://music-api.gdstudio.xyz/api.php",
-        
+        baseUrl: "/proxy",
+
         generateSignature: () => {
             return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
         },
 
-        jsonpRequest: (url) => {
-            return new Promise((resolve, reject) => {
-                const callbackName = "jsonp_callback_" + Math.random().toString(36).substr(2, 9);
-                const timestamp = Date.now();
-                const script = document.createElement("script");
-                
-                window[callbackName] = function(data) {
-                    resolve(data);
-                    document.head.removeChild(script);
-                    delete window[callbackName];
-                };
-                
-                const separator = url.includes("?") ? "&" : "?";
-                const finalUrl = `${url}${separator}callback=${callbackName}&_=${timestamp}`;
-                
-                script.src = finalUrl;
-                script.onerror = () => {
-                    reject(new Error("JSONP request failed"));
-                    document.head.removeChild(script);
-                    delete window[callbackName];
-                };
-                
-                document.head.appendChild(script);
-            });
+        fetchJson: async (url) => {
+            try {
+                const response = await fetch(url, {
+                    headers: {
+                        "Accept": "application/json",
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`);
+                }
+
+                const text = await response.text();
+                try {
+                    return JSON.parse(text);
+                } catch (parseError) {
+                    console.warn("JSON parse failed, returning raw text", parseError);
+                    return text;
+                }
+            } catch (error) {
+                console.error("API request error:", error);
+                throw error;
+            }
         },
 
         search: async (keyword, source = "netease", count = 20, page = 1) => {
             const signature = API.generateSignature();
             const url = `${API.baseUrl}?types=search&source=${source}&name=${encodeURIComponent(keyword)}&count=${count}&pages=${page}&s=${signature}`;
-            
+
             try {
                 debugLog(`API请求: ${url}`);
-                const data = await API.jsonpRequest(url);
+                const data = await API.fetchJson(url);
                 debugLog(`API响应: ${JSON.stringify(data).substring(0, 200)}...`);
-                
+
                 if (!Array.isArray(data)) throw new Error("搜索结果格式错误");
                 
                 return data.map(song => ({
@@ -1810,9 +1829,9 @@
             const source = "netease,kuwo";
             const signature = API.generateSignature();
             const url = `${API.baseUrl}?types=search&source=${source}&name=${encodeURIComponent(keyword)}&count=${count}&pages=${pages}&s=${signature}`;
-            
+
             try {
-                const data = await API.jsonpRequest(url);
+                const data = await API.fetchJson(url);
                 if (!Array.isArray(data) || data.length === 0) throw new Error("No songs found");
                 return data.map(song => ({
                     id: song.id,
@@ -2622,7 +2641,7 @@
                 const picUrl = API.getPicUrl(song);
                 
                 // 修复：直接使用JSONP请求获取封面数据
-                const data = await API.jsonpRequest(picUrl);
+                const data = await API.fetchJson(picUrl);
                 
                 if (data && data.url) {
                     // 预加载图片以确保加载成功
@@ -3121,19 +3140,24 @@
             const audioUrl = API.getSongUrl(song, quality);
             debugLog(`获取音频URL: ${audioUrl}`);
 
-            const audioData = await API.jsonpRequest(audioUrl);
+            const audioData = await API.fetchJson(audioUrl);
 
             if (!audioData || !audioData.url) {
                 throw new Error('无法获取音频播放地址');
             }
 
             const originalAudioUrl = audioData.url;
+            const proxiedAudioUrl = buildAudioProxyUrl(originalAudioUrl);
             const preferredAudioUrl = preferHttpsUrl(originalAudioUrl);
             const candidateAudioUrls = Array.from(
-                new Set([preferredAudioUrl, originalAudioUrl].filter(Boolean))
+                new Set([proxiedAudioUrl, preferredAudioUrl, originalAudioUrl].filter(Boolean))
             );
 
-            if (preferredAudioUrl && preferredAudioUrl !== originalAudioUrl) {
+            const primaryAudioUrl = candidateAudioUrls[0] || originalAudioUrl;
+
+            if (proxiedAudioUrl && proxiedAudioUrl !== originalAudioUrl) {
+                debugLog(`音频地址已通过代理转换为 HTTPS: ${proxiedAudioUrl}`);
+            } else if (preferredAudioUrl && preferredAudioUrl !== originalAudioUrl) {
                 debugLog(`音频地址由 HTTP 升级为 HTTPS: ${preferredAudioUrl}`);
             }
 
@@ -3164,18 +3188,14 @@
                 try {
                     await waitForAudioReady(dom.audioPlayer);
                     selectedAudioUrl = candidateUrl;
-                    usedFallbackAudio = (
-                        candidateUrl !== preferredAudioUrl &&
-                        candidateAudioUrls.length > 1 &&
-                        preferredAudioUrl !== originalAudioUrl
-                    );
+                    usedFallbackAudio = candidateUrl !== primaryAudioUrl && candidateAudioUrls.length > 1;
                     break;
                 } catch (error) {
                     lastAudioError = error;
                     console.warn('音频元数据加载异常', error);
 
-                    if (candidateUrl === preferredAudioUrl && candidateAudioUrls.length > 1) {
-                        debugLog('HTTPS 音频加载失败，尝试回退到原始地址');
+                    if (candidateUrl === primaryAudioUrl && candidateAudioUrls.length > 1) {
+                        debugLog('主音频地址加载失败，尝试使用备用地址');
                     }
                 }
             }
@@ -3185,8 +3205,8 @@
             }
 
             if (usedFallbackAudio) {
-                debugLog(`已回退至原始音频地址: ${selectedAudioUrl}`);
-                showNotification('HTTPS 音频加载失败，已切换到备用音源', 'warning');
+                debugLog(`已回退至备用音频地址: ${selectedAudioUrl}`);
+                showNotification('主音频加载失败，已切换到备用音源', 'warning');
             }
 
             state.currentAudioUrl = selectedAudioUrl;
@@ -3378,7 +3398,7 @@
             const lyricUrl = API.getLyric(song);
             debugLog(`获取歌词URL: ${lyricUrl}`);
             
-            const lyricData = await API.jsonpRequest(lyricUrl);
+            const lyricData = await API.fetchJson(lyricUrl);
             
             if (lyricData && lyricData.lyric) {
                 parseLyrics(lyricData.lyric);
@@ -3494,21 +3514,27 @@
             showNotification("正在准备下载...");
 
             const audioUrl = API.getSongUrl(song, quality);
-            const audioData = await API.jsonpRequest(audioUrl);
+            const audioData = await API.fetchJson(audioUrl);
 
             if (audioData && audioData.url) {
+                const proxiedAudioUrl = buildAudioProxyUrl(audioData.url);
                 const preferredAudioUrl = preferHttpsUrl(audioData.url);
-                if (preferredAudioUrl !== audioData.url) {
+
+                if (proxiedAudioUrl !== audioData.url) {
+                    debugLog(`下载链接已通过代理转换为 HTTPS: ${proxiedAudioUrl}`);
+                } else if (preferredAudioUrl !== audioData.url) {
                     debugLog(`下载链接由 HTTP 升级为 HTTPS: ${preferredAudioUrl}`);
                 }
 
+                const downloadUrl = proxiedAudioUrl || preferredAudioUrl || audioData.url;
+
                 const link = document.createElement("a");
-                link.href = preferredAudioUrl;
+                link.href = downloadUrl;
                 const preferredExtension =
                     quality === "999" ? "flac" : quality === "740" ? "ape" : "mp3";
                 const fileExtension = (() => {
                     try {
-                        const url = new URL(preferredAudioUrl);
+                        const url = new URL(audioData.url);
                         const pathname = url.pathname || "";
                         const match = pathname.match(/\.([a-z0-9]+)$/i);
                         if (match) {


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages Function that proxies API calls and Kuwo audio over HTTPS with CORS headers
- migrate the front-end API utilities from JSONP to direct fetch requests through the proxy
- wrap playback and download URLs with the proxy to avoid mixed-content issues and improve fallback handling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68e2b4e7ba9c832b880577b3e9cba5c1