### PR TITLE
feat: derive theme gradient from album art

### DIFF
--- a/functions/palette.ts
+++ b/functions/palette.ts
@@ -1,0 +1,382 @@
+const MAX_DIMENSION = 120;
+const TARGET_SAMPLE_COUNT = 4000;
+
+interface PaletteStop {
+  gradient: string;
+  colors: string[];
+}
+
+interface ThemeTokens {
+  primaryColor: string;
+  primaryColorDark: string;
+}
+
+interface PaletteResponse {
+  source: string;
+  baseColor: string;
+  averageColor: string;
+  accentColor: string;
+  contrastColor: string;
+  gradients: Record<"light" | "dark", PaletteStop>;
+  tokens: Record<"light" | "dark", ThemeTokens>;
+}
+
+interface HslColor {
+  h: number;
+  s: number;
+  l: number;
+}
+
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface AnalyzedColors {
+  average: HslColor;
+  accent: HslColor;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function componentToHex(value: number): string {
+  const clamped = clamp(Math.round(value), 0, 255);
+  return clamped.toString(16).padStart(2, "0");
+}
+
+function rgbToHex({ r, g, b }: RgbColor): string {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+}
+
+function rgbToHsl(r: number, g: number, b: number): HslColor {
+  const rNorm = clamp(r / 255, 0, 1);
+  const gNorm = clamp(g / 255, 0, 1);
+  const bNorm = clamp(b / 255, 0, 1);
+
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rNorm) {
+      h = ((gNorm - bNorm) / delta) % 6;
+    } else if (max === gNorm) {
+      h = (bNorm - rNorm) / delta + 2;
+    } else {
+      h = (rNorm - gNorm) / delta + 4;
+    }
+    h *= 60;
+    if (h < 0) {
+      h += 360;
+    }
+  }
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  return { h, s, l };
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
+function hslToRgb(h: number, s: number, l: number): RgbColor {
+  const saturation = clamp(s, 0, 1);
+  const lightness = clamp(l, 0, 1);
+
+  const normalizedHue = ((h % 360) + 360) % 360 / 360;
+
+  if (saturation === 0) {
+    const value = lightness * 255;
+    return { r: value, g: value, b: value };
+  }
+
+  const q = lightness < 0.5
+    ? lightness * (1 + saturation)
+    : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+
+  const r = hueToRgb(p, q, normalizedHue + 1 / 3) * 255;
+  const g = hueToRgb(p, q, normalizedHue) * 255;
+  const b = hueToRgb(p, q, normalizedHue - 1 / 3) * 255;
+
+  return { r, g, b };
+}
+
+function hslToHex(color: HslColor): string {
+  const rgb = hslToRgb(color.h, color.s, color.l);
+  return rgbToHex(rgb);
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  const normalize = (value: number) => {
+    const channel = clamp(value / 255, 0, 1);
+    return channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+
+  const rLin = normalize(r);
+  const gLin = normalize(g);
+  const bLin = normalize(b);
+
+  return 0.2126 * rLin + 0.7152 * gLin + 0.0722 * bLin;
+}
+
+function pickContrastColor(color: RgbColor): string {
+  const luminance = relativeLuminance(color.r, color.g, color.b);
+  return luminance > 0.45 ? "#1f2937" : "#f8fafc";
+}
+
+function adjustSaturation(base: number, factor: number, offset = 0): number {
+  return clamp(base * factor + offset, 0, 1);
+}
+
+function adjustLightness(base: number, offset: number, factor = 1): number {
+  return clamp(base * factor + offset, 0, 1);
+}
+
+function analyzeImageColors(imageData: ImageData): AnalyzedColors {
+  const { data } = imageData;
+  const totalPixels = data.length / 4;
+  const step = Math.max(1, Math.floor(totalPixels / TARGET_SAMPLE_COUNT));
+
+  let totalR = 0;
+  let totalG = 0;
+  let totalB = 0;
+  let count = 0;
+
+  let accent: { color: HslColor; score: number } | null = null;
+
+  for (let index = 0; index < data.length; index += step * 4) {
+    const alpha = data[index + 3];
+    if (alpha < 48) {
+      continue;
+    }
+
+    const r = data[index];
+    const g = data[index + 1];
+    const b = data[index + 2];
+
+    totalR += r;
+    totalG += g;
+    totalB += b;
+    count++;
+
+    const hsl = rgbToHsl(r, g, b);
+    const vibrance = hsl.s;
+    const balance = 1 - Math.abs(hsl.l - 0.5);
+    const score = vibrance * 0.65 + balance * 0.35;
+
+    if (!accent || score > accent.score) {
+      accent = { color: hsl, score };
+    }
+  }
+
+  if (count === 0) {
+    throw new Error("No opaque pixels available for analysis");
+  }
+
+  const averageR = totalR / count;
+  const averageG = totalG / count;
+  const averageB = totalB / count;
+  const average = rgbToHsl(averageR, averageG, averageB);
+
+  const accentColor = accent ? accent.color : average;
+
+  return {
+    average,
+    accent: accentColor,
+  };
+}
+
+function buildGradientStops(accent: HslColor): { light: PaletteStop; dark: PaletteStop } {
+  const lightColors = [
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.65, 0.15), l: adjustLightness(accent.l, 0.32) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.9), l: adjustLightness(accent.l, 0.12) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 1.05), l: adjustLightness(accent.l, -0.05) }),
+  ];
+
+  const darkColors = [
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.75), l: adjustLightness(accent.l, 0, 0.45) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.85), l: adjustLightness(accent.l, 0.08, 0.32) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 1), l: adjustLightness(accent.l, 0.04, 0.18) }),
+  ];
+
+  return {
+    light: {
+      colors: lightColors,
+      gradient: `linear-gradient(140deg, ${lightColors[0]} 0%, ${lightColors[1]} 45%, ${lightColors[2]} 100%)`,
+    },
+    dark: {
+      colors: darkColors,
+      gradient: `linear-gradient(135deg, ${darkColors[0]} 0%, ${darkColors[1]} 55%, ${darkColors[2]} 100%)`,
+    },
+  };
+}
+
+function buildThemeTokens(accent: HslColor): Record<"light" | "dark", ThemeTokens> {
+  return {
+    light: {
+      primaryColor: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.92, 0.04), l: adjustLightness(accent.l, 0.1) }),
+      primaryColorDark: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 1.05), l: adjustLightness(accent.l, -0.06) }),
+    },
+    dark: {
+      primaryColor: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.85), l: adjustLightness(accent.l, 0.1, 0.55) }),
+      primaryColorDark: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.9), l: adjustLightness(accent.l, 0.05, 0.38) }),
+    },
+  };
+}
+
+async function decodeImage(arrayBuffer: ArrayBuffer, contentType: string): Promise<ImageData> {
+  const blob = new Blob([arrayBuffer], { type: contentType });
+  const bitmap = await createImageBitmap(blob);
+
+  try {
+    const scale = Math.min(1, MAX_DIMENSION / Math.max(bitmap.width, bitmap.height));
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) {
+      throw new Error("Unable to create canvas context");
+    }
+
+    context.drawImage(bitmap, 0, 0, width, height);
+    return context.getImageData(0, 0, width, height);
+  } finally {
+    bitmap.close();
+  }
+}
+
+async function buildPalette(arrayBuffer: ArrayBuffer, contentType: string): Promise<PaletteResponse> {
+  const imageData = await decodeImage(arrayBuffer, contentType);
+  const analyzed = analyzeImageColors(imageData);
+  const gradientStops = buildGradientStops(analyzed.accent);
+  const tokens = buildThemeTokens(analyzed.accent);
+
+  const accentRgb = hslToRgb(analyzed.accent.h, analyzed.accent.s, analyzed.accent.l);
+
+  return {
+    source: "",
+    baseColor: hslToHex(analyzed.accent),
+    averageColor: hslToHex(analyzed.average),
+    accentColor: hslToHex(analyzed.accent),
+    contrastColor: pickContrastColor(accentRgb),
+    gradients: {
+      light: gradientStops.light,
+      dark: gradientStops.dark,
+    },
+    tokens,
+  };
+}
+
+function createCorsHeaders(init?: HeadersInit): Headers {
+  const headers = new Headers(init);
+  headers.set("Access-Control-Allow-Origin", "*");
+  return headers;
+}
+
+function createJsonHeaders(status: number): Headers {
+  const headers = createCorsHeaders({
+    "Content-Type": "application/json; charset=utf-8",
+  });
+  headers.set("Cache-Control", status === 200 ? "public, max-age=3600" : "no-store");
+  return headers;
+}
+
+function handleOptions(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}
+
+export async function onRequest({ request }: { request: Request }): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return handleOptions();
+  }
+
+  if (request.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: createJsonHeaders(405),
+    });
+  }
+
+  const url = new URL(request.url);
+  const imageParam = url.searchParams.get("image") ?? url.searchParams.get("url");
+
+  if (!imageParam) {
+    return new Response(JSON.stringify({ error: "Missing image parameter" }), {
+      status: 400,
+      headers: createJsonHeaders(400),
+    });
+  }
+
+  let target: URL;
+  try {
+    target = new URL(imageParam);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid image URL" }), {
+      status: 400,
+      headers: createJsonHeaders(400),
+    });
+  }
+
+  const upstream = await fetch(target.toString(), {
+    cf: {
+      cacheTtl: 3600,
+      cacheEverything: true,
+    },
+  });
+
+  if (!upstream.ok) {
+    return new Response(JSON.stringify({ error: `Upstream request failed with status ${upstream.status}` }), {
+      status: upstream.status,
+      headers: createJsonHeaders(upstream.status),
+    });
+  }
+
+  const contentType = upstream.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("image/")) {
+    return new Response(JSON.stringify({ error: "Unsupported content type" }), {
+      status: 415,
+      headers: createJsonHeaders(415),
+    });
+  }
+
+  const buffer = await upstream.arrayBuffer();
+
+  try {
+    const palette = await buildPalette(buffer, contentType);
+    palette.source = target.toString();
+
+    return new Response(JSON.stringify(palette), {
+      status: 200,
+      headers: createJsonHeaders(200),
+    });
+  } catch (error) {
+    console.error("Palette generation failed", error);
+    return new Response(JSON.stringify({ error: "Failed to analyze image" }), {
+      status: 500,
+      headers: createJsonHeaders(500),
+    });
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1642,6 +1642,22 @@
         qualityLabel: document.getElementById("qualityLabel"),
     };
 
+    const PLACEHOLDER_HTML = `<div class="placeholder"><i class="fas fa-music"></i></div>`;
+    const paletteCache = new Map();
+    const themeDefaults = {
+        light: {
+            gradient: "",
+            primaryColor: "",
+            primaryColorDark: "",
+        },
+        dark: {
+            gradient: "",
+            primaryColor: "",
+            primaryColorDark: "",
+        }
+    };
+    let paletteRequestId = 0;
+
     function safeGetLocalStorage(key) {
         try {
             return localStorage.getItem(key);
@@ -1908,7 +1924,135 @@
         sourceMenuOpen: false,
         userScrolledLyrics: false, // 新增：用户是否手动滚动歌词
         lyricsScrollTimeout: null, // 新增：歌词滚动超时
+        themeDefaultsCaptured: false,
+        dynamicPalette: null,
+        currentPaletteImage: null,
     };
+
+    function captureThemeDefaults() {
+        if (state.themeDefaultsCaptured) {
+            return;
+        }
+
+        const initialIsDark = document.body.classList.contains("dark-mode");
+        document.body.classList.remove("dark-mode");
+        const lightStyles = getComputedStyle(document.body);
+        themeDefaults.light.gradient = lightStyles.getPropertyValue("--bg-gradient").trim();
+        themeDefaults.light.primaryColor = lightStyles.getPropertyValue("--primary-color").trim();
+        themeDefaults.light.primaryColorDark = lightStyles.getPropertyValue("--primary-color-dark").trim();
+
+        document.body.classList.add("dark-mode");
+        const darkStyles = getComputedStyle(document.body);
+        themeDefaults.dark.gradient = darkStyles.getPropertyValue("--bg-gradient").trim();
+        themeDefaults.dark.primaryColor = darkStyles.getPropertyValue("--primary-color").trim();
+        themeDefaults.dark.primaryColorDark = darkStyles.getPropertyValue("--primary-color-dark").trim();
+
+        if (!initialIsDark) {
+            document.body.classList.remove("dark-mode");
+        }
+
+        state.themeDefaultsCaptured = true;
+    }
+
+    function applyThemeTokens(tokens) {
+        if (!tokens) return;
+        if (tokens.primaryColor) {
+            document.documentElement.style.setProperty("--primary-color", tokens.primaryColor);
+        }
+        if (tokens.primaryColorDark) {
+            document.documentElement.style.setProperty("--primary-color-dark", tokens.primaryColorDark);
+        }
+    }
+
+    function applyDynamicGradient() {
+        if (!state.themeDefaultsCaptured) {
+            captureThemeDefaults();
+        }
+        const isDark = document.body.classList.contains("dark-mode");
+        const mode = isDark ? "dark" : "light";
+        const defaults = themeDefaults[mode];
+
+        if (defaults.gradient) {
+            document.documentElement.style.setProperty("--bg-gradient", defaults.gradient);
+        } else {
+            document.documentElement.style.removeProperty("--bg-gradient");
+        }
+        applyThemeTokens(defaults);
+
+        const palette = state.dynamicPalette;
+        if (palette && palette.gradients && palette.gradients[mode]) {
+            const gradientInfo = palette.gradients[mode];
+            if (gradientInfo && gradientInfo.gradient) {
+                document.documentElement.style.setProperty("--bg-gradient", gradientInfo.gradient);
+            }
+            if (palette.tokens && palette.tokens[mode]) {
+                applyThemeTokens(palette.tokens[mode]);
+            }
+        }
+    }
+
+    function resetDynamicBackground() {
+        paletteRequestId += 1;
+        state.dynamicPalette = null;
+        state.currentPaletteImage = null;
+        applyDynamicGradient();
+    }
+
+    function showAlbumCoverPlaceholder() {
+        dom.albumCover.innerHTML = PLACEHOLDER_HTML;
+        dom.albumCover.classList.remove("loading");
+        resetDynamicBackground();
+    }
+
+    function setAlbumCoverImage(url) {
+        dom.albumCover.innerHTML = `<img src="${url}" alt="专辑封面">`;
+        dom.albumCover.classList.remove("loading");
+    }
+
+    async function fetchPaletteData(imageUrl) {
+        if (paletteCache.has(imageUrl)) {
+            return paletteCache.get(imageUrl);
+        }
+
+        const response = await fetch(`/palette?image=${encodeURIComponent(imageUrl)}`);
+        if (!response.ok) {
+            throw new Error(`Palette request failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+        paletteCache.set(imageUrl, data);
+        return data;
+    }
+
+    async function updateDynamicBackground(imageUrl) {
+        paletteRequestId += 1;
+        const requestId = paletteRequestId;
+
+        if (!imageUrl) {
+            resetDynamicBackground();
+            return;
+        }
+
+        if (state.currentPaletteImage === imageUrl && state.dynamicPalette) {
+            applyDynamicGradient();
+            return;
+        }
+
+        try {
+            const palette = await fetchPaletteData(imageUrl);
+            if (requestId !== paletteRequestId) {
+                return;
+            }
+            state.dynamicPalette = palette;
+            state.currentPaletteImage = imageUrl;
+            applyDynamicGradient();
+        } catch (error) {
+            console.warn("获取动态背景失败:", error);
+            if (requestId === paletteRequestId) {
+                resetDynamicBackground();
+            }
+        }
+    }
 
     function savePlayerState() {
         safeSetLocalStorage("playlistSongs", JSON.stringify(state.playlistSongs));
@@ -2494,13 +2638,18 @@
 
     function setupInteractions() {
         function applyTheme(isDark) {
+            if (!state.themeDefaultsCaptured) {
+                captureThemeDefaults();
+            }
             document.body.classList.toggle("dark-mode", isDark);
             dom.themeToggleButton.classList.toggle("is-dark", isDark);
             const label = isDark ? "切换为浅色模式" : "切换为深色模式";
             dom.themeToggleButton.setAttribute("aria-label", label);
             dom.themeToggleButton.setAttribute("title", label);
+            applyDynamicGradient();
         }
 
+        captureThemeDefaults();
         const savedTheme = safeGetLocalStorage("theme");
         const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
         const initialIsDark = savedTheme ? savedTheme === "dark" : prefersDark;
@@ -2710,34 +2859,32 @@
             try {
                 dom.albumCover.classList.add("loading");
                 const picUrl = API.getPicUrl(song);
-                
+
                 // 修复：直接使用JSONP请求获取封面数据
                 const data = await API.fetchJson(picUrl);
-                
+
                 if (data && data.url) {
                     // 预加载图片以确保加载成功
                     const img = new Image();
+                    const imageUrl = preferHttpsUrl(data.url);
+                    img.crossOrigin = "anonymous";
                     img.onload = () => {
-                        dom.albumCover.innerHTML = `<img src="${data.url}" alt="专辑封面">`;
-                        dom.albumCover.classList.remove("loading");
+                        setAlbumCoverImage(imageUrl);
+                        updateDynamicBackground(imageUrl);
                     };
                     img.onerror = () => {
-                        dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-                        dom.albumCover.classList.remove("loading");
+                        showAlbumCoverPlaceholder();
                     };
-                    img.src = data.url;
+                    img.src = imageUrl;
                 } else {
-                    dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-                    dom.albumCover.classList.remove("loading");
+                    showAlbumCoverPlaceholder();
                 }
             } catch (error) {
                 console.error("加载封面失败:", error);
-                dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-                dom.albumCover.classList.remove("loading");
+                showAlbumCoverPlaceholder();
             }
         } else {
-            dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-            dom.albumCover.classList.remove("loading");
+            showAlbumCoverPlaceholder();
         }
     }
     
@@ -3072,7 +3219,7 @@
                 updateProgressBarBackground(0, 1);
                 dom.currentSongTitle.textContent = "选择一首歌曲开始播放";
                 dom.currentSongArtist.textContent = "未知艺术家";
-                dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
+                showAlbumCoverPlaceholder();
                 dom.lyrics.innerHTML = "";
                 dom.lyrics.classList.add("empty");
                 updatePlayPauseButton();
@@ -3130,7 +3277,7 @@
             updateProgressBarBackground(0, 1);
             dom.currentSongTitle.textContent = "选择一首歌曲开始播放";
             dom.currentSongArtist.textContent = "未知艺术家";
-            dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
+            showAlbumCoverPlaceholder();
             dom.lyrics.innerHTML = "";
             dom.lyrics.classList.add("empty");
             updatePlayPauseButton();


### PR DESCRIPTION
## Summary
- add a Cloudflare function that analyses cover art colours and returns gradient + accent tokens
- update the player to request dynamic palettes per track and fall back gracefully on errors
- refresh playlist maintenance paths to reuse the shared album placeholder helper

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2c97691cc832b9d8ca08bf18c4b28