### PR TITLE
fix: stabilize palette extraction in worker

### DIFF
--- a/functions/lib/vendor/jpeg-decoder.js
+++ b/functions/lib/vendor/jpeg-decoder.js
@@ -1,0 +1,1148 @@
+// @ts-nocheck
+/* -*- tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/*
+   Copyright 2011 notmasteryet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// - The JPEG specification can be found in the ITU CCITT Recommendation T.81
+//   (www.w3.org/Graphics/JPEG/itu-t81.pdf)
+// - The JFIF specification can be found in the JPEG File Interchange Format
+//   (www.w3.org/Graphics/JPEG/jfif3.pdf)
+// - The Adobe Application-Specific JPEG markers in the Supporting the DCT Filters
+//   in PostScript Level 2, Technical Note #5116
+//   (partners.adobe.com/public/developer/en/ps/sdk/5116.DCT_Filter.pdf)
+
+var JpegImage = (function jpegImage() {
+  "use strict";
+  var dctZigZag = new Int32Array([
+     0,
+     1,  8,
+    16,  9,  2,
+     3, 10, 17, 24,
+    32, 25, 18, 11, 4,
+     5, 12, 19, 26, 33, 40,
+    48, 41, 34, 27, 20, 13,  6,
+     7, 14, 21, 28, 35, 42, 49, 56,
+    57, 50, 43, 36, 29, 22, 15,
+    23, 30, 37, 44, 51, 58,
+    59, 52, 45, 38, 31,
+    39, 46, 53, 60,
+    61, 54, 47,
+    55, 62,
+    63
+  ]);
+
+  var dctCos1  =  4017   // cos(pi/16)
+  var dctSin1  =   799   // sin(pi/16)
+  var dctCos3  =  3406   // cos(3*pi/16)
+  var dctSin3  =  2276   // sin(3*pi/16)
+  var dctCos6  =  1567   // cos(6*pi/16)
+  var dctSin6  =  3784   // sin(6*pi/16)
+  var dctSqrt2 =  5793   // sqrt(2)
+  var dctSqrt1d2 = 2896  // sqrt(2) / 2
+
+  function constructor() {
+  }
+
+  function buildHuffmanTable(codeLengths, values) {
+    var k = 0, code = [], i, j, length = 16;
+    while (length > 0 && !codeLengths[length - 1])
+      length--;
+    code.push({children: [], index: 0});
+    var p = code[0], q;
+    for (i = 0; i < length; i++) {
+      for (j = 0; j < codeLengths[i]; j++) {
+        p = code.pop();
+        p.children[p.index] = values[k];
+        while (p.index > 0) {
+          if (code.length === 0)
+            throw new Error('Could not recreate Huffman Table');
+          p = code.pop();
+        }
+        p.index++;
+        code.push(p);
+        while (code.length <= i) {
+          code.push(q = {children: [], index: 0});
+          p.children[p.index] = q.children;
+          p = q;
+        }
+        k++;
+      }
+      if (i + 1 < length) {
+        // p here points to last code
+        code.push(q = {children: [], index: 0});
+        p.children[p.index] = q.children;
+        p = q;
+      }
+    }
+    return code[0].children;
+  }
+
+  function decodeScan(data, offset,
+                      frame, components, resetInterval,
+                      spectralStart, spectralEnd,
+                      successivePrev, successive, opts) {
+    var precision = frame.precision;
+    var samplesPerLine = frame.samplesPerLine;
+    var scanLines = frame.scanLines;
+    var mcusPerLine = frame.mcusPerLine;
+    var progressive = frame.progressive;
+    var maxH = frame.maxH, maxV = frame.maxV;
+
+    var startOffset = offset, bitsData = 0, bitsCount = 0;
+    function readBit() {
+      if (bitsCount > 0) {
+        bitsCount--;
+        return (bitsData >> bitsCount) & 1;
+      }
+      bitsData = data[offset++];
+      if (bitsData == 0xFF) {
+        var nextByte = data[offset++];
+        if (nextByte) {
+          throw new Error("unexpected marker: " + ((bitsData << 8) | nextByte).toString(16));
+        }
+        // unstuff 0
+      }
+      bitsCount = 7;
+      return bitsData >>> 7;
+    }
+    function decodeHuffman(tree) {
+      var node = tree, bit;
+      while ((bit = readBit()) !== null) {
+        node = node[bit];
+        if (typeof node === 'number')
+          return node;
+        if (typeof node !== 'object')
+          throw new Error("invalid huffman sequence");
+      }
+      return null;
+    }
+    function receive(length) {
+      var n = 0;
+      while (length > 0) {
+        var bit = readBit();
+        if (bit === null) return;
+        n = (n << 1) | bit;
+        length--;
+      }
+      return n;
+    }
+    function receiveAndExtend(length) {
+      var n = receive(length);
+      if (n >= 1 << (length - 1))
+        return n;
+      return n + (-1 << length) + 1;
+    }
+    function decodeBaseline(component, zz) {
+      var t = decodeHuffman(component.huffmanTableDC);
+      var diff = t === 0 ? 0 : receiveAndExtend(t);
+      zz[0]= (component.pred += diff);
+      var k = 1;
+      while (k < 64) {
+        var rs = decodeHuffman(component.huffmanTableAC);
+        var s = rs & 15, r = rs >> 4;
+        if (s === 0) {
+          if (r < 15)
+            break;
+          k += 16;
+          continue;
+        }
+        k += r;
+        var z = dctZigZag[k];
+        zz[z] = receiveAndExtend(s);
+        k++;
+      }
+    }
+    function decodeDCFirst(component, zz) {
+      var t = decodeHuffman(component.huffmanTableDC);
+      var diff = t === 0 ? 0 : (receiveAndExtend(t) << successive);
+      zz[0] = (component.pred += diff);
+    }
+    function decodeDCSuccessive(component, zz) {
+      zz[0] |= readBit() << successive;
+    }
+    var eobrun = 0;
+    function decodeACFirst(component, zz) {
+      if (eobrun > 0) {
+        eobrun--;
+        return;
+      }
+      var k = spectralStart, e = spectralEnd;
+      while (k <= e) {
+        var rs = decodeHuffman(component.huffmanTableAC);
+        var s = rs & 15, r = rs >> 4;
+        if (s === 0) {
+          if (r < 15) {
+            eobrun = receive(r) + (1 << r) - 1;
+            break;
+          }
+          k += 16;
+          continue;
+        }
+        k += r;
+        var z = dctZigZag[k];
+        zz[z] = receiveAndExtend(s) * (1 << successive);
+        k++;
+      }
+    }
+    var successiveACState = 0, successiveACNextValue;
+    function decodeACSuccessive(component, zz) {
+      var k = spectralStart, e = spectralEnd, r = 0;
+      while (k <= e) {
+        var z = dctZigZag[k];
+        var direction = zz[z] < 0 ? -1 : 1;
+        switch (successiveACState) {
+        case 0: // initial state
+          var rs = decodeHuffman(component.huffmanTableAC);
+          var s = rs & 15, r = rs >> 4;
+          if (s === 0) {
+            if (r < 15) {
+              eobrun = receive(r) + (1 << r);
+              successiveACState = 4;
+            } else {
+              r = 16;
+              successiveACState = 1;
+            }
+          } else {
+            if (s !== 1)
+              throw new Error("invalid ACn encoding");
+            successiveACNextValue = receiveAndExtend(s);
+            successiveACState = r ? 2 : 3;
+          }
+          continue;
+        case 1: // skipping r zero items
+        case 2:
+          if (zz[z])
+            zz[z] += (readBit() << successive) * direction;
+          else {
+            r--;
+            if (r === 0)
+              successiveACState = successiveACState == 2 ? 3 : 0;
+          }
+          break;
+        case 3: // set value for a zero item
+          if (zz[z])
+            zz[z] += (readBit() << successive) * direction;
+          else {
+            zz[z] = successiveACNextValue << successive;
+            successiveACState = 0;
+          }
+          break;
+        case 4: // eob
+          if (zz[z])
+            zz[z] += (readBit() << successive) * direction;
+          break;
+        }
+        k++;
+      }
+      if (successiveACState === 4) {
+        eobrun--;
+        if (eobrun === 0)
+          successiveACState = 0;
+      }
+    }
+    function decodeMcu(component, decode, mcu, row, col) {
+      var mcuRow = (mcu / mcusPerLine) | 0;
+      var mcuCol = mcu % mcusPerLine;
+      var blockRow = mcuRow * component.v + row;
+      var blockCol = mcuCol * component.h + col;
+      // If the block is missing and we're in tolerant mode, just skip it.
+      if (component.blocks[blockRow] === undefined && opts.tolerantDecoding)
+        return;
+      decode(component, component.blocks[blockRow][blockCol]);
+    }
+    function decodeBlock(component, decode, mcu) {
+      var blockRow = (mcu / component.blocksPerLine) | 0;
+      var blockCol = mcu % component.blocksPerLine;
+      // If the block is missing and we're in tolerant mode, just skip it.
+      if (component.blocks[blockRow] === undefined && opts.tolerantDecoding)
+        return;
+      decode(component, component.blocks[blockRow][blockCol]);
+    }
+
+    var componentsLength = components.length;
+    var component, i, j, k, n;
+    var decodeFn;
+    if (progressive) {
+      if (spectralStart === 0)
+        decodeFn = successivePrev === 0 ? decodeDCFirst : decodeDCSuccessive;
+      else
+        decodeFn = successivePrev === 0 ? decodeACFirst : decodeACSuccessive;
+    } else {
+      decodeFn = decodeBaseline;
+    }
+
+    var mcu = 0, marker;
+    var mcuExpected;
+    if (componentsLength == 1) {
+      mcuExpected = components[0].blocksPerLine * components[0].blocksPerColumn;
+    } else {
+      mcuExpected = mcusPerLine * frame.mcusPerColumn;
+    }
+    if (!resetInterval) resetInterval = mcuExpected;
+
+    var h, v;
+    while (mcu < mcuExpected) {
+      // reset interval stuff
+      for (i = 0; i < componentsLength; i++)
+        components[i].pred = 0;
+      eobrun = 0;
+
+      if (componentsLength == 1) {
+        component = components[0];
+        for (n = 0; n < resetInterval; n++) {
+          decodeBlock(component, decodeFn, mcu);
+          mcu++;
+        }
+      } else {
+        for (n = 0; n < resetInterval; n++) {
+          for (i = 0; i < componentsLength; i++) {
+            component = components[i];
+            h = component.h;
+            v = component.v;
+            for (j = 0; j < v; j++) {
+              for (k = 0; k < h; k++) {
+                decodeMcu(component, decodeFn, mcu, j, k);
+              }
+            }
+          }
+          mcu++;
+
+          // If we've reached our expected MCU's, stop decoding
+          if (mcu === mcuExpected) break;
+        }
+      }
+
+      if (mcu === mcuExpected) {
+        // Skip trailing bytes at the end of the scan - until we reach the next marker
+        do {
+          if (data[offset] === 0xFF) {
+            if (data[offset + 1] !== 0x00) {
+              break;
+            }
+          }
+          offset += 1;
+        } while (offset < data.length - 2);
+      }
+
+      // find marker
+      bitsCount = 0;
+      marker = (data[offset] << 8) | data[offset + 1];
+      if (marker < 0xFF00) {
+        throw new Error("marker was not found");
+      }
+
+      if (marker >= 0xFFD0 && marker <= 0xFFD7) { // RSTx
+        offset += 2;
+      }
+      else
+        break;
+    }
+
+    return offset - startOffset;
+  }
+
+  function buildComponentData(frame, component) {
+    var lines = [];
+    var blocksPerLine = component.blocksPerLine;
+    var blocksPerColumn = component.blocksPerColumn;
+    var samplesPerLine = blocksPerLine << 3;
+    // Only 1 used per invocation of this function and garbage collected after invocation, so no need to account for its memory footprint.
+    var R = new Int32Array(64), r = new Uint8Array(64);
+
+    // A port of poppler's IDCT method which in turn is taken from:
+    //   Christoph Loeffler, Adriaan Ligtenberg, George S. Moschytz,
+    //   "Practical Fast 1-D DCT Algorithms with 11 Multiplications",
+    //   IEEE Intl. Conf. on Acoustics, Speech & Signal Processing, 1989,
+    //   988-991.
+    function quantizeAndInverse(zz, dataOut, dataIn) {
+      var qt = component.quantizationTable;
+      var v0, v1, v2, v3, v4, v5, v6, v7, t;
+      var p = dataIn;
+      var i;
+
+      // dequant
+      for (i = 0; i < 64; i++)
+        p[i] = zz[i] * qt[i];
+
+      // inverse DCT on rows
+      for (i = 0; i < 8; ++i) {
+        var row = 8 * i;
+
+        // check for all-zero AC coefficients
+        if (p[1 + row] == 0 && p[2 + row] == 0 && p[3 + row] == 0 &&
+            p[4 + row] == 0 && p[5 + row] == 0 && p[6 + row] == 0 &&
+            p[7 + row] == 0) {
+          t = (dctSqrt2 * p[0 + row] + 512) >> 10;
+          p[0 + row] = t;
+          p[1 + row] = t;
+          p[2 + row] = t;
+          p[3 + row] = t;
+          p[4 + row] = t;
+          p[5 + row] = t;
+          p[6 + row] = t;
+          p[7 + row] = t;
+          continue;
+        }
+
+        // stage 4
+        v0 = (dctSqrt2 * p[0 + row] + 128) >> 8;
+        v1 = (dctSqrt2 * p[4 + row] + 128) >> 8;
+        v2 = p[2 + row];
+        v3 = p[6 + row];
+        v4 = (dctSqrt1d2 * (p[1 + row] - p[7 + row]) + 128) >> 8;
+        v7 = (dctSqrt1d2 * (p[1 + row] + p[7 + row]) + 128) >> 8;
+        v5 = p[3 + row] << 4;
+        v6 = p[5 + row] << 4;
+
+        // stage 3
+        t = (v0 - v1+ 1) >> 1;
+        v0 = (v0 + v1 + 1) >> 1;
+        v1 = t;
+        t = (v2 * dctSin6 + v3 * dctCos6 + 128) >> 8;
+        v2 = (v2 * dctCos6 - v3 * dctSin6 + 128) >> 8;
+        v3 = t;
+        t = (v4 - v6 + 1) >> 1;
+        v4 = (v4 + v6 + 1) >> 1;
+        v6 = t;
+        t = (v7 + v5 + 1) >> 1;
+        v5 = (v7 - v5 + 1) >> 1;
+        v7 = t;
+
+        // stage 2
+        t = (v0 - v3 + 1) >> 1;
+        v0 = (v0 + v3 + 1) >> 1;
+        v3 = t;
+        t = (v1 - v2 + 1) >> 1;
+        v1 = (v1 + v2 + 1) >> 1;
+        v2 = t;
+        t = (v4 * dctSin3 + v7 * dctCos3 + 2048) >> 12;
+        v4 = (v4 * dctCos3 - v7 * dctSin3 + 2048) >> 12;
+        v7 = t;
+        t = (v5 * dctSin1 + v6 * dctCos1 + 2048) >> 12;
+        v5 = (v5 * dctCos1 - v6 * dctSin1 + 2048) >> 12;
+        v6 = t;
+
+        // stage 1
+        p[0 + row] = v0 + v7;
+        p[7 + row] = v0 - v7;
+        p[1 + row] = v1 + v6;
+        p[6 + row] = v1 - v6;
+        p[2 + row] = v2 + v5;
+        p[5 + row] = v2 - v5;
+        p[3 + row] = v3 + v4;
+        p[4 + row] = v3 - v4;
+      }
+
+      // inverse DCT on columns
+      for (i = 0; i < 8; ++i) {
+        var col = i;
+
+        // check for all-zero AC coefficients
+        if (p[1*8 + col] == 0 && p[2*8 + col] == 0 && p[3*8 + col] == 0 &&
+            p[4*8 + col] == 0 && p[5*8 + col] == 0 && p[6*8 + col] == 0 &&
+            p[7*8 + col] == 0) {
+          t = (dctSqrt2 * dataIn[i+0] + 8192) >> 14;
+          p[0*8 + col] = t;
+          p[1*8 + col] = t;
+          p[2*8 + col] = t;
+          p[3*8 + col] = t;
+          p[4*8 + col] = t;
+          p[5*8 + col] = t;
+          p[6*8 + col] = t;
+          p[7*8 + col] = t;
+          continue;
+        }
+
+        // stage 4
+        v0 = (dctSqrt2 * p[0*8 + col] + 2048) >> 12;
+        v1 = (dctSqrt2 * p[4*8 + col] + 2048) >> 12;
+        v2 = p[2*8 + col];
+        v3 = p[6*8 + col];
+        v4 = (dctSqrt1d2 * (p[1*8 + col] - p[7*8 + col]) + 2048) >> 12;
+        v7 = (dctSqrt1d2 * (p[1*8 + col] + p[7*8 + col]) + 2048) >> 12;
+        v5 = p[3*8 + col];
+        v6 = p[5*8 + col];
+
+        // stage 3
+        t = (v0 - v1 + 1) >> 1;
+        v0 = (v0 + v1 + 1) >> 1;
+        v1 = t;
+        t = (v2 * dctSin6 + v3 * dctCos6 + 2048) >> 12;
+        v2 = (v2 * dctCos6 - v3 * dctSin6 + 2048) >> 12;
+        v3 = t;
+        t = (v4 - v6 + 1) >> 1;
+        v4 = (v4 + v6 + 1) >> 1;
+        v6 = t;
+        t = (v7 + v5 + 1) >> 1;
+        v5 = (v7 - v5 + 1) >> 1;
+        v7 = t;
+
+        // stage 2
+        t = (v0 - v3 + 1) >> 1;
+        v0 = (v0 + v3 + 1) >> 1;
+        v3 = t;
+        t = (v1 - v2 + 1) >> 1;
+        v1 = (v1 + v2 + 1) >> 1;
+        v2 = t;
+        t = (v4 * dctSin3 + v7 * dctCos3 + 2048) >> 12;
+        v4 = (v4 * dctCos3 - v7 * dctSin3 + 2048) >> 12;
+        v7 = t;
+        t = (v5 * dctSin1 + v6 * dctCos1 + 2048) >> 12;
+        v5 = (v5 * dctCos1 - v6 * dctSin1 + 2048) >> 12;
+        v6 = t;
+
+        // stage 1
+        p[0*8 + col] = v0 + v7;
+        p[7*8 + col] = v0 - v7;
+        p[1*8 + col] = v1 + v6;
+        p[6*8 + col] = v1 - v6;
+        p[2*8 + col] = v2 + v5;
+        p[5*8 + col] = v2 - v5;
+        p[3*8 + col] = v3 + v4;
+        p[4*8 + col] = v3 - v4;
+      }
+
+      // convert to 8-bit integers
+      for (i = 0; i < 64; ++i) {
+        var sample = 128 + ((p[i] + 8) >> 4);
+        dataOut[i] = sample < 0 ? 0 : sample > 0xFF ? 0xFF : sample;
+      }
+    }
+
+    requestMemoryAllocation(samplesPerLine * blocksPerColumn * 8);
+
+    var i, j;
+    for (var blockRow = 0; blockRow < blocksPerColumn; blockRow++) {
+      var scanLine = blockRow << 3;
+      for (i = 0; i < 8; i++)
+        lines.push(new Uint8Array(samplesPerLine));
+      for (var blockCol = 0; blockCol < blocksPerLine; blockCol++) {
+        quantizeAndInverse(component.blocks[blockRow][blockCol], r, R);
+
+        var offset = 0, sample = blockCol << 3;
+        for (j = 0; j < 8; j++) {
+          var line = lines[scanLine + j];
+          for (i = 0; i < 8; i++)
+            line[sample + i] = r[offset++];
+        }
+      }
+    }
+    return lines;
+  }
+
+  function clampTo8bit(a) {
+    return a < 0 ? 0 : a > 255 ? 255 : a;
+  }
+
+  constructor.prototype = {
+    load: function load(path) {
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", path, true);
+      xhr.responseType = "arraybuffer";
+      xhr.onload = (function() {
+        // TODO catch parse error
+        var data = new Uint8Array(xhr.response || xhr.mozResponseArrayBuffer);
+        this.parse(data);
+        if (this.onload)
+          this.onload();
+      }).bind(this);
+      xhr.send(null);
+    },
+    parse: function parse(data) {
+      var maxResolutionInPixels = this.opts.maxResolutionInMP * 1000 * 1000;
+      var offset = 0, length = data.length;
+      function readUint16() {
+        var value = (data[offset] << 8) | data[offset + 1];
+        offset += 2;
+        return value;
+      }
+      function readDataBlock() {
+        var length = readUint16();
+        var array = data.subarray(offset, offset + length - 2);
+        offset += array.length;
+        return array;
+      }
+      function prepareComponents(frame) {
+        // According to the JPEG standard, the sampling factor must be between 1 and 4
+        // See https://github.com/libjpeg-turbo/libjpeg-turbo/blob/9abeff46d87bd201a952e276f3e4339556a403a3/libjpeg.txt#L1138-L1146
+        var maxH = 1, maxV = 1;
+        var component, componentId;
+        for (componentId in frame.components) {
+          if (frame.components.hasOwnProperty(componentId)) {
+            component = frame.components[componentId];
+            if (maxH < component.h) maxH = component.h;
+            if (maxV < component.v) maxV = component.v;
+          }
+        }
+        var mcusPerLine = Math.ceil(frame.samplesPerLine / 8 / maxH);
+        var mcusPerColumn = Math.ceil(frame.scanLines / 8 / maxV);
+        for (componentId in frame.components) {
+          if (frame.components.hasOwnProperty(componentId)) {
+            component = frame.components[componentId];
+            var blocksPerLine = Math.ceil(Math.ceil(frame.samplesPerLine / 8) * component.h / maxH);
+            var blocksPerColumn = Math.ceil(Math.ceil(frame.scanLines  / 8) * component.v / maxV);
+            var blocksPerLineForMcu = mcusPerLine * component.h;
+            var blocksPerColumnForMcu = mcusPerColumn * component.v;
+            var blocksToAllocate = blocksPerColumnForMcu * blocksPerLineForMcu;
+            var blocks = [];
+
+            // Each block is a Int32Array of length 64 (4 x 64 = 256 bytes)
+            requestMemoryAllocation(blocksToAllocate * 256);
+
+            for (var i = 0; i < blocksPerColumnForMcu; i++) {
+              var row = [];
+              for (var j = 0; j < blocksPerLineForMcu; j++)
+                row.push(new Int32Array(64));
+              blocks.push(row);
+            }
+            component.blocksPerLine = blocksPerLine;
+            component.blocksPerColumn = blocksPerColumn;
+            component.blocks = blocks;
+          }
+        }
+        frame.maxH = maxH;
+        frame.maxV = maxV;
+        frame.mcusPerLine = mcusPerLine;
+        frame.mcusPerColumn = mcusPerColumn;
+      }
+      var jfif = null;
+      var adobe = null;
+      var pixels = null;
+      var frame, resetInterval;
+      var quantizationTables = [], frames = [];
+      var huffmanTablesAC = [], huffmanTablesDC = [];
+      var fileMarker = readUint16();
+      var malformedDataOffset = -1;
+      this.comments = [];
+      if (fileMarker != 0xFFD8) { // SOI (Start of Image)
+        throw new Error("SOI not found");
+      }
+
+      fileMarker = readUint16();
+      while (fileMarker != 0xFFD9) { // EOI (End of image)
+        var i, j, l;
+        switch(fileMarker) {
+          case 0xFF00: break;
+          case 0xFFE0: // APP0 (Application Specific)
+          case 0xFFE1: // APP1
+          case 0xFFE2: // APP2
+          case 0xFFE3: // APP3
+          case 0xFFE4: // APP4
+          case 0xFFE5: // APP5
+          case 0xFFE6: // APP6
+          case 0xFFE7: // APP7
+          case 0xFFE8: // APP8
+          case 0xFFE9: // APP9
+          case 0xFFEA: // APP10
+          case 0xFFEB: // APP11
+          case 0xFFEC: // APP12
+          case 0xFFED: // APP13
+          case 0xFFEE: // APP14
+          case 0xFFEF: // APP15
+          case 0xFFFE: // COM (Comment)
+            var appData = readDataBlock();
+
+            if (fileMarker === 0xFFFE) {
+              var comment = String.fromCharCode.apply(null, appData);
+              this.comments.push(comment);
+            }
+
+            if (fileMarker === 0xFFE0) {
+              if (appData[0] === 0x4A && appData[1] === 0x46 && appData[2] === 0x49 &&
+                appData[3] === 0x46 && appData[4] === 0) { // 'JFIF\x00'
+                jfif = {
+                  version: { major: appData[5], minor: appData[6] },
+                  densityUnits: appData[7],
+                  xDensity: (appData[8] << 8) | appData[9],
+                  yDensity: (appData[10] << 8) | appData[11],
+                  thumbWidth: appData[12],
+                  thumbHeight: appData[13],
+                  thumbData: appData.subarray(14, 14 + 3 * appData[12] * appData[13])
+                };
+              }
+            }
+            // TODO APP1 - Exif
+            if (fileMarker === 0xFFE1) {
+              if (appData[0] === 0x45 &&
+                appData[1] === 0x78 &&
+                appData[2] === 0x69 &&
+                appData[3] === 0x66 &&
+                appData[4] === 0) { // 'EXIF\x00'
+                this.exifBuffer = appData.subarray(5, appData.length);
+              }
+            }
+
+            if (fileMarker === 0xFFEE) {
+              if (appData[0] === 0x41 && appData[1] === 0x64 && appData[2] === 0x6F &&
+                appData[3] === 0x62 && appData[4] === 0x65 && appData[5] === 0) { // 'Adobe\x00'
+                adobe = {
+                  version: appData[6],
+                  flags0: (appData[7] << 8) | appData[8],
+                  flags1: (appData[9] << 8) | appData[10],
+                  transformCode: appData[11]
+                };
+              }
+            }
+            break;
+
+          case 0xFFDB: // DQT (Define Quantization Tables)
+            var quantizationTablesLength = readUint16();
+            var quantizationTablesEnd = quantizationTablesLength + offset - 2;
+            while (offset < quantizationTablesEnd) {
+              var quantizationTableSpec = data[offset++];
+              requestMemoryAllocation(64 * 4);
+              var tableData = new Int32Array(64);
+              if ((quantizationTableSpec >> 4) === 0) { // 8 bit values
+                for (j = 0; j < 64; j++) {
+                  var z = dctZigZag[j];
+                  tableData[z] = data[offset++];
+                }
+              } else if ((quantizationTableSpec >> 4) === 1) { //16 bit
+                for (j = 0; j < 64; j++) {
+                  var z = dctZigZag[j];
+                  tableData[z] = readUint16();
+                }
+              } else
+                throw new Error("DQT: invalid table spec");
+              quantizationTables[quantizationTableSpec & 15] = tableData;
+            }
+            break;
+
+          case 0xFFC0: // SOF0 (Start of Frame, Baseline DCT)
+          case 0xFFC1: // SOF1 (Start of Frame, Extended DCT)
+          case 0xFFC2: // SOF2 (Start of Frame, Progressive DCT)
+            readUint16(); // skip data length
+            frame = {};
+            frame.extended = (fileMarker === 0xFFC1);
+            frame.progressive = (fileMarker === 0xFFC2);
+            frame.precision = data[offset++];
+            frame.scanLines = readUint16();
+            frame.samplesPerLine = readUint16();
+            frame.components = {};
+            frame.componentsOrder = [];
+
+            var pixelsInFrame = frame.scanLines * frame.samplesPerLine;
+            if (pixelsInFrame > maxResolutionInPixels) {
+              var exceededAmount = Math.ceil((pixelsInFrame - maxResolutionInPixels) / 1e6);
+              throw new Error(`maxResolutionInMP limit exceeded by ${exceededAmount}MP`);
+            }
+
+            var componentsCount = data[offset++], componentId;
+            var maxH = 0, maxV = 0;
+            for (i = 0; i < componentsCount; i++) {
+              componentId = data[offset];
+              var h = data[offset + 1] >> 4;
+              var v = data[offset + 1] & 15;
+              var qId = data[offset + 2];
+
+              if ( h <= 0 || v <= 0 ) {
+                throw new Error('Invalid sampling factor, expected values above 0');
+              }
+
+              frame.componentsOrder.push(componentId);
+              frame.components[componentId] = {
+                h: h,
+                v: v,
+                quantizationIdx: qId
+              };
+              offset += 3;
+            }
+            prepareComponents(frame);
+            frames.push(frame);
+            break;
+
+          case 0xFFC4: // DHT (Define Huffman Tables)
+            var huffmanLength = readUint16();
+            for (i = 2; i < huffmanLength;) {
+              var huffmanTableSpec = data[offset++];
+              var codeLengths = new Uint8Array(16);
+              var codeLengthSum = 0;
+              for (j = 0; j < 16; j++, offset++) {
+                codeLengthSum += (codeLengths[j] = data[offset]);
+              }
+              requestMemoryAllocation(16 + codeLengthSum);
+              var huffmanValues = new Uint8Array(codeLengthSum);
+              for (j = 0; j < codeLengthSum; j++, offset++)
+                huffmanValues[j] = data[offset];
+              i += 17 + codeLengthSum;
+
+              ((huffmanTableSpec >> 4) === 0 ?
+                huffmanTablesDC : huffmanTablesAC)[huffmanTableSpec & 15] =
+                buildHuffmanTable(codeLengths, huffmanValues);
+            }
+            break;
+
+          case 0xFFDD: // DRI (Define Restart Interval)
+            readUint16(); // skip data length
+            resetInterval = readUint16();
+            break;
+
+          case 0xFFDC: // Number of Lines marker
+            readUint16() // skip data length
+            readUint16() // Ignore this data since it represents the image height
+            break;
+            
+          case 0xFFDA: // SOS (Start of Scan)
+            var scanLength = readUint16();
+            var selectorsCount = data[offset++];
+            var components = [], component;
+            for (i = 0; i < selectorsCount; i++) {
+              component = frame.components[data[offset++]];
+              var tableSpec = data[offset++];
+              component.huffmanTableDC = huffmanTablesDC[tableSpec >> 4];
+              component.huffmanTableAC = huffmanTablesAC[tableSpec & 15];
+              components.push(component);
+            }
+            var spectralStart = data[offset++];
+            var spectralEnd = data[offset++];
+            var successiveApproximation = data[offset++];
+            var processed = decodeScan(data, offset,
+              frame, components, resetInterval,
+              spectralStart, spectralEnd,
+              successiveApproximation >> 4, successiveApproximation & 15, this.opts);
+            offset += processed;
+            break;
+
+          case 0xFFFF: // Fill bytes
+            if (data[offset] !== 0xFF) { // Avoid skipping a valid marker.
+              offset--;
+            }
+            break;
+          default:
+            if (data[offset - 3] == 0xFF &&
+                data[offset - 2] >= 0xC0 && data[offset - 2] <= 0xFE) {
+              // could be incorrect encoding -- last 0xFF byte of the previous
+              // block was eaten by the encoder
+              offset -= 3;
+              break;
+            }
+            else if (fileMarker === 0xE0 || fileMarker == 0xE1) {
+              // Recover from malformed APP1 markers popular in some phone models.
+              // See https://github.com/eugeneware/jpeg-js/issues/82
+              if (malformedDataOffset !== -1) {
+                throw new Error(`first unknown JPEG marker at offset ${malformedDataOffset.toString(16)}, second unknown JPEG marker ${fileMarker.toString(16)} at offset ${(offset - 1).toString(16)}`);
+              }
+              malformedDataOffset = offset - 1;
+              const nextOffset = readUint16();
+              if (data[offset + nextOffset - 2] === 0xFF) {
+                offset += nextOffset - 2;
+                break;
+              }
+            }
+            throw new Error("unknown JPEG marker " + fileMarker.toString(16));
+        }
+        fileMarker = readUint16();
+      }
+      if (frames.length != 1)
+        throw new Error("only single frame JPEGs supported");
+
+      // set each frame's components quantization table
+      for (var i = 0; i < frames.length; i++) {
+        var cp = frames[i].components;
+        for (var j in cp) {
+          cp[j].quantizationTable = quantizationTables[cp[j].quantizationIdx];
+          delete cp[j].quantizationIdx;
+        }
+      }
+
+      this.width = frame.samplesPerLine;
+      this.height = frame.scanLines;
+      this.jfif = jfif;
+      this.adobe = adobe;
+      this.components = [];
+      for (var i = 0; i < frame.componentsOrder.length; i++) {
+        var component = frame.components[frame.componentsOrder[i]];
+        this.components.push({
+          lines: buildComponentData(frame, component),
+          scaleX: component.h / frame.maxH,
+          scaleY: component.v / frame.maxV
+        });
+      }
+    },
+    getData: function getData(width, height) {
+      var scaleX = this.width / width, scaleY = this.height / height;
+
+      var component1, component2, component3, component4;
+      var component1Line, component2Line, component3Line, component4Line;
+      var x, y;
+      var offset = 0;
+      var Y, Cb, Cr, K, C, M, Ye, R, G, B;
+      var colorTransform;
+      var dataLength = width * height * this.components.length;
+      requestMemoryAllocation(dataLength);
+      var data = new Uint8Array(dataLength);
+      switch (this.components.length) {
+        case 1:
+          component1 = this.components[0];
+          for (y = 0; y < height; y++) {
+            component1Line = component1.lines[0 | (y * component1.scaleY * scaleY)];
+            for (x = 0; x < width; x++) {
+              Y = component1Line[0 | (x * component1.scaleX * scaleX)];
+
+              data[offset++] = Y;
+            }
+          }
+          break;
+        case 2:
+          // PDF might compress two component data in custom colorspace
+          component1 = this.components[0];
+          component2 = this.components[1];
+          for (y = 0; y < height; y++) {
+            component1Line = component1.lines[0 | (y * component1.scaleY * scaleY)];
+            component2Line = component2.lines[0 | (y * component2.scaleY * scaleY)];
+            for (x = 0; x < width; x++) {
+              Y = component1Line[0 | (x * component1.scaleX * scaleX)];
+              data[offset++] = Y;
+              Y = component2Line[0 | (x * component2.scaleX * scaleX)];
+              data[offset++] = Y;
+            }
+          }
+          break;
+        case 3:
+          // The default transform for three components is true
+          colorTransform = true;
+          // The adobe transform marker overrides any previous setting
+          if (this.adobe && this.adobe.transformCode)
+            colorTransform = true;
+          else if (typeof this.opts.colorTransform !== 'undefined')
+            colorTransform = !!this.opts.colorTransform;
+
+          component1 = this.components[0];
+          component2 = this.components[1];
+          component3 = this.components[2];
+          for (y = 0; y < height; y++) {
+            component1Line = component1.lines[0 | (y * component1.scaleY * scaleY)];
+            component2Line = component2.lines[0 | (y * component2.scaleY * scaleY)];
+            component3Line = component3.lines[0 | (y * component3.scaleY * scaleY)];
+            for (x = 0; x < width; x++) {
+              if (!colorTransform) {
+                R = component1Line[0 | (x * component1.scaleX * scaleX)];
+                G = component2Line[0 | (x * component2.scaleX * scaleX)];
+                B = component3Line[0 | (x * component3.scaleX * scaleX)];
+              } else {
+                Y = component1Line[0 | (x * component1.scaleX * scaleX)];
+                Cb = component2Line[0 | (x * component2.scaleX * scaleX)];
+                Cr = component3Line[0 | (x * component3.scaleX * scaleX)];
+
+                R = clampTo8bit(Y + 1.402 * (Cr - 128));
+                G = clampTo8bit(Y - 0.3441363 * (Cb - 128) - 0.71413636 * (Cr - 128));
+                B = clampTo8bit(Y + 1.772 * (Cb - 128));
+              }
+
+              data[offset++] = R;
+              data[offset++] = G;
+              data[offset++] = B;
+            }
+          }
+          break;
+        case 4:
+          if (!this.adobe)
+            throw new Error('Unsupported color mode (4 components)');
+          // The default transform for four components is false
+          colorTransform = false;
+          // The adobe transform marker overrides any previous setting
+          if (this.adobe && this.adobe.transformCode)
+            colorTransform = true;
+          else if (typeof this.opts.colorTransform !== 'undefined')
+            colorTransform = !!this.opts.colorTransform;
+
+          component1 = this.components[0];
+          component2 = this.components[1];
+          component3 = this.components[2];
+          component4 = this.components[3];
+          for (y = 0; y < height; y++) {
+            component1Line = component1.lines[0 | (y * component1.scaleY * scaleY)];
+            component2Line = component2.lines[0 | (y * component2.scaleY * scaleY)];
+            component3Line = component3.lines[0 | (y * component3.scaleY * scaleY)];
+            component4Line = component4.lines[0 | (y * component4.scaleY * scaleY)];
+            for (x = 0; x < width; x++) {
+              if (!colorTransform) {
+                C = component1Line[0 | (x * component1.scaleX * scaleX)];
+                M = component2Line[0 | (x * component2.scaleX * scaleX)];
+                Ye = component3Line[0 | (x * component3.scaleX * scaleX)];
+                K = component4Line[0 | (x * component4.scaleX * scaleX)];
+              } else {
+                Y = component1Line[0 | (x * component1.scaleX * scaleX)];
+                Cb = component2Line[0 | (x * component2.scaleX * scaleX)];
+                Cr = component3Line[0 | (x * component3.scaleX * scaleX)];
+                K = component4Line[0 | (x * component4.scaleX * scaleX)];
+
+                C = 255 - clampTo8bit(Y + 1.402 * (Cr - 128));
+                M = 255 - clampTo8bit(Y - 0.3441363 * (Cb - 128) - 0.71413636 * (Cr - 128));
+                Ye = 255 - clampTo8bit(Y + 1.772 * (Cb - 128));
+              }
+              data[offset++] = 255-C;
+              data[offset++] = 255-M;
+              data[offset++] = 255-Ye;
+              data[offset++] = 255-K;
+            }
+          }
+          break;
+        default:
+          throw new Error('Unsupported color mode');
+      }
+      return data;
+    },
+    copyToImageData: function copyToImageData(imageData, formatAsRGBA) {
+      var width = imageData.width, height = imageData.height;
+      var imageDataArray = imageData.data;
+      var data = this.getData(width, height);
+      var i = 0, j = 0, x, y;
+      var Y, K, C, M, R, G, B;
+      switch (this.components.length) {
+        case 1:
+          for (y = 0; y < height; y++) {
+            for (x = 0; x < width; x++) {
+              Y = data[i++];
+
+              imageDataArray[j++] = Y;
+              imageDataArray[j++] = Y;
+              imageDataArray[j++] = Y;
+              if (formatAsRGBA) {
+                imageDataArray[j++] = 255;
+              }
+            }
+          }
+          break;
+        case 3:
+          for (y = 0; y < height; y++) {
+            for (x = 0; x < width; x++) {
+              R = data[i++];
+              G = data[i++];
+              B = data[i++];
+
+              imageDataArray[j++] = R;
+              imageDataArray[j++] = G;
+              imageDataArray[j++] = B;
+              if (formatAsRGBA) {
+                imageDataArray[j++] = 255;
+              }
+            }
+          }
+          break;
+        case 4:
+          for (y = 0; y < height; y++) {
+            for (x = 0; x < width; x++) {
+              C = data[i++];
+              M = data[i++];
+              Y = data[i++];
+              K = data[i++];
+
+              R = 255 - clampTo8bit(C * (1 - K / 255) + K);
+              G = 255 - clampTo8bit(M * (1 - K / 255) + K);
+              B = 255 - clampTo8bit(Y * (1 - K / 255) + K);
+
+              imageDataArray[j++] = R;
+              imageDataArray[j++] = G;
+              imageDataArray[j++] = B;
+              if (formatAsRGBA) {
+                imageDataArray[j++] = 255;
+              }
+            }
+          }
+          break;
+        default:
+          throw new Error('Unsupported color mode');
+      }
+    }
+  };
+
+
+  // We cap the amount of memory used by jpeg-js to avoid unexpected OOMs from untrusted content.
+  var totalBytesAllocated = 0;
+  var maxMemoryUsageBytes = 0;
+  function requestMemoryAllocation(increaseAmount = 0) {
+    var totalMemoryImpactBytes = totalBytesAllocated + increaseAmount;
+    if (totalMemoryImpactBytes > maxMemoryUsageBytes) {
+      var exceededAmount = Math.ceil((totalMemoryImpactBytes - maxMemoryUsageBytes) / 1024 / 1024);
+      throw new Error(`maxMemoryUsageInMB limit exceeded by at least ${exceededAmount}MB`);
+    }
+
+    totalBytesAllocated = totalMemoryImpactBytes;
+  }
+
+  constructor.resetMaxMemoryUsage = function (maxMemoryUsageBytes_) {
+    totalBytesAllocated = 0;
+    maxMemoryUsageBytes = maxMemoryUsageBytes_;
+  };
+
+  constructor.getBytesAllocated = function () {
+    return totalBytesAllocated;
+  };
+
+  constructor.requestMemoryAllocation = requestMemoryAllocation;
+
+  return constructor;
+})();
+
+function decode(jpegData, userOpts = {}) {
+  var defaultOpts = {
+    // "undefined" means "Choose whether to transform colors based on the image’s color model."
+    colorTransform: undefined,
+    useTArray: false,
+    formatAsRGBA: true,
+    tolerantDecoding: true,
+    maxResolutionInMP: 100, // Don't decode more than 100 megapixels
+    maxMemoryUsageInMB: 512, // Don't decode if memory footprint is more than 512MB
+  };
+
+  var opts = {...defaultOpts, ...userOpts};
+  var arr = new Uint8Array(jpegData);
+  var decoder = new JpegImage();
+  decoder.opts = opts;
+  // If this constructor ever supports async decoding this will need to be done differently.
+  // Until then, treating as singleton limit is fine.
+  JpegImage.resetMaxMemoryUsage(opts.maxMemoryUsageInMB * 1024 * 1024);
+  decoder.parse(arr);
+
+  var channels = (opts.formatAsRGBA) ? 4 : 3;
+  var bytesNeeded = decoder.width * decoder.height * channels;
+  try {
+    JpegImage.requestMemoryAllocation(bytesNeeded);
+    var image = {
+      width: decoder.width,
+      height: decoder.height,
+      exifBuffer: decoder.exifBuffer,
+      data: opts.useTArray ?
+        new Uint8Array(bytesNeeded) :
+        Buffer.alloc(bytesNeeded)
+    };
+    if(decoder.comments.length > 0) {
+      image["comments"] = decoder.comments;
+    }
+  } catch (err) {
+    if (err instanceof RangeError) {
+      throw new Error("Could not allocate enough memory for the image. " +
+                      "Required: " + bytesNeeded);
+    } 
+    
+    if (err instanceof ReferenceError) {
+      if (err.message === "Buffer is not defined") {
+        throw new Error("Buffer is not globally defined in this environment. " +
+                        "Consider setting useTArray to true");
+      }
+    }
+    throw err;
+  }
+
+  decoder.copyToImageData(image, opts.formatAsRGBA);
+
+  return image;
+}
+
+export default decode;
+export { decode };

--- a/functions/palette.ts
+++ b/functions/palette.ts
@@ -1,0 +1,438 @@
+import decodeJpeg from "./lib/vendor/jpeg-decoder.js";
+
+const MAX_DIMENSION = 120;
+const TARGET_SAMPLE_COUNT = 4000;
+
+type SupportedFormat = "jpeg" | "jpg" | "pjpeg";
+
+interface DecodedImage {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+class UnsupportedImageFormatError extends Error {
+  constructor(format: string) {
+    super(`Unsupported image format: ${format}`);
+    this.name = "UnsupportedImageFormatError";
+  }
+}
+
+interface PaletteStop {
+  gradient: string;
+  colors: string[];
+}
+
+interface ThemeTokens {
+  primaryColor: string;
+  primaryColorDark: string;
+}
+
+interface PaletteResponse {
+  source: string;
+  baseColor: string;
+  averageColor: string;
+  accentColor: string;
+  contrastColor: string;
+  gradients: Record<"light" | "dark", PaletteStop>;
+  tokens: Record<"light" | "dark", ThemeTokens>;
+}
+
+interface HslColor {
+  h: number;
+  s: number;
+  l: number;
+}
+
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface AnalyzedColors {
+  average: HslColor;
+  accent: HslColor;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function componentToHex(value: number): string {
+  const clamped = clamp(Math.round(value), 0, 255);
+  return clamped.toString(16).padStart(2, "0");
+}
+
+function rgbToHex({ r, g, b }: RgbColor): string {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+}
+
+function rgbToHsl(r: number, g: number, b: number): HslColor {
+  const rNorm = clamp(r / 255, 0, 1);
+  const gNorm = clamp(g / 255, 0, 1);
+  const bNorm = clamp(b / 255, 0, 1);
+
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rNorm) {
+      h = ((gNorm - bNorm) / delta) % 6;
+    } else if (max === gNorm) {
+      h = (bNorm - rNorm) / delta + 2;
+    } else {
+      h = (rNorm - gNorm) / delta + 4;
+    }
+    h *= 60;
+    if (h < 0) {
+      h += 360;
+    }
+  }
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  return { h, s, l };
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
+function hslToRgb(h: number, s: number, l: number): RgbColor {
+  const saturation = clamp(s, 0, 1);
+  const lightness = clamp(l, 0, 1);
+
+  const normalizedHue = ((h % 360) + 360) % 360 / 360;
+
+  if (saturation === 0) {
+    const value = lightness * 255;
+    return { r: value, g: value, b: value };
+  }
+
+  const q = lightness < 0.5
+    ? lightness * (1 + saturation)
+    : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+
+  const r = hueToRgb(p, q, normalizedHue + 1 / 3) * 255;
+  const g = hueToRgb(p, q, normalizedHue) * 255;
+  const b = hueToRgb(p, q, normalizedHue - 1 / 3) * 255;
+
+  return { r, g, b };
+}
+
+function hslToHex(color: HslColor): string {
+  const rgb = hslToRgb(color.h, color.s, color.l);
+  return rgbToHex(rgb);
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  const normalize = (value: number) => {
+    const channel = clamp(value / 255, 0, 1);
+    return channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+
+  const rLin = normalize(r);
+  const gLin = normalize(g);
+  const bLin = normalize(b);
+
+  return 0.2126 * rLin + 0.7152 * gLin + 0.0722 * bLin;
+}
+
+function pickContrastColor(color: RgbColor): string {
+  const luminance = relativeLuminance(color.r, color.g, color.b);
+  return luminance > 0.45 ? "#1f2937" : "#f8fafc";
+}
+
+function adjustSaturation(base: number, factor: number, offset = 0): number {
+  return clamp(base * factor + offset, 0, 1);
+}
+
+function adjustLightness(base: number, offset: number, factor = 1): number {
+  return clamp(base * factor + offset, 0, 1);
+}
+
+function analyzeImageColors(image: DecodedImage): AnalyzedColors {
+  const { data } = image;
+  const totalPixels = data.length / 4;
+  const step = Math.max(1, Math.floor(totalPixels / TARGET_SAMPLE_COUNT));
+
+  let totalR = 0;
+  let totalG = 0;
+  let totalB = 0;
+  let count = 0;
+
+  let accent: { color: HslColor; score: number } | null = null;
+
+  for (let index = 0; index < data.length; index += step * 4) {
+    const alpha = data[index + 3];
+    if (alpha < 48) {
+      continue;
+    }
+
+    const r = data[index];
+    const g = data[index + 1];
+    const b = data[index + 2];
+
+    totalR += r;
+    totalG += g;
+    totalB += b;
+    count++;
+
+    const hsl = rgbToHsl(r, g, b);
+    const vibrance = hsl.s;
+    const balance = 1 - Math.abs(hsl.l - 0.5);
+    const score = vibrance * 0.65 + balance * 0.35;
+
+    if (!accent || score > accent.score) {
+      accent = { color: hsl, score };
+    }
+  }
+
+  if (count === 0) {
+    throw new Error("No opaque pixels available for analysis");
+  }
+
+  const averageR = totalR / count;
+  const averageG = totalG / count;
+  const averageB = totalB / count;
+  const average = rgbToHsl(averageR, averageG, averageB);
+
+  const accentColor = accent ? accent.color : average;
+
+  return {
+    average,
+    accent: accentColor,
+  };
+}
+
+function buildGradientStops(accent: HslColor): { light: PaletteStop; dark: PaletteStop } {
+  const lightColors = [
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.65, 0.15), l: adjustLightness(accent.l, 0.32) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.9), l: adjustLightness(accent.l, 0.12) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 1.05), l: adjustLightness(accent.l, -0.05) }),
+  ];
+
+  const darkColors = [
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.75), l: adjustLightness(accent.l, 0, 0.45) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.85), l: adjustLightness(accent.l, 0.08, 0.32) }),
+    hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 1), l: adjustLightness(accent.l, 0.04, 0.18) }),
+  ];
+
+  return {
+    light: {
+      colors: lightColors,
+      gradient: `linear-gradient(140deg, ${lightColors[0]} 0%, ${lightColors[1]} 45%, ${lightColors[2]} 100%)`,
+    },
+    dark: {
+      colors: darkColors,
+      gradient: `linear-gradient(135deg, ${darkColors[0]} 0%, ${darkColors[1]} 55%, ${darkColors[2]} 100%)`,
+    },
+  };
+}
+
+function buildThemeTokens(accent: HslColor): Record<"light" | "dark", ThemeTokens> {
+  return {
+    light: {
+      primaryColor: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.92, 0.04), l: adjustLightness(accent.l, 0.1) }),
+      primaryColorDark: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 1.05), l: adjustLightness(accent.l, -0.06) }),
+    },
+    dark: {
+      primaryColor: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.85), l: adjustLightness(accent.l, 0.1, 0.55) }),
+      primaryColorDark: hslToHex({ h: accent.h, s: adjustSaturation(accent.s, 0.9), l: adjustLightness(accent.l, 0.05, 0.38) }),
+    },
+  };
+}
+
+function resizeImage(image: DecodedImage): DecodedImage {
+  const maxSide = Math.max(image.width, image.height);
+  if (maxSide <= MAX_DIMENSION) {
+    return image;
+  }
+
+  const scale = MAX_DIMENSION / maxSide;
+  const width = Math.max(1, Math.round(image.width * scale));
+  const height = Math.max(1, Math.round(image.height * scale));
+  const resized = new Uint8ClampedArray(width * height * 4);
+
+  for (let y = 0; y < height; y += 1) {
+    const srcY = Math.min(image.height - 1, Math.floor(y / scale));
+    for (let x = 0; x < width; x += 1) {
+      const srcX = Math.min(image.width - 1, Math.floor(x / scale));
+      const srcIndex = (srcY * image.width + srcX) * 4;
+      const destIndex = (y * width + x) * 4;
+
+      resized[destIndex] = image.data[srcIndex];
+      resized[destIndex + 1] = image.data[srcIndex + 1];
+      resized[destIndex + 2] = image.data[srcIndex + 2];
+      resized[destIndex + 3] = image.data[srcIndex + 3];
+    }
+  }
+
+  return {
+    width,
+    height,
+    data: resized,
+  };
+}
+
+function decodeImage(arrayBuffer: ArrayBuffer, contentType: string): DecodedImage {
+  const subtype = contentType.split("/")[1]?.split(";")[0]?.toLowerCase() ?? "";
+  const supported: SupportedFormat[] = ["jpeg", "jpg", "pjpeg"];
+  if (!supported.includes(subtype as SupportedFormat)) {
+    throw new UnsupportedImageFormatError(subtype);
+  }
+
+  const bytes = new Uint8Array(arrayBuffer);
+  const decoded = decodeJpeg(bytes, {
+    useTArray: true,
+    formatAsRGBA: true,
+  });
+
+  const image: DecodedImage = {
+    width: decoded.width,
+    height: decoded.height,
+    data: new Uint8ClampedArray(decoded.data),
+  };
+
+  return resizeImage(image);
+}
+
+async function buildPalette(arrayBuffer: ArrayBuffer, contentType: string): Promise<PaletteResponse> {
+  const imageData = decodeImage(arrayBuffer, contentType);
+  const analyzed = analyzeImageColors(imageData);
+  const gradientStops = buildGradientStops(analyzed.accent);
+  const tokens = buildThemeTokens(analyzed.accent);
+
+  const accentRgb = hslToRgb(analyzed.accent.h, analyzed.accent.s, analyzed.accent.l);
+
+  return {
+    source: "",
+    baseColor: hslToHex(analyzed.accent),
+    averageColor: hslToHex(analyzed.average),
+    accentColor: hslToHex(analyzed.accent),
+    contrastColor: pickContrastColor(accentRgb),
+    gradients: {
+      light: gradientStops.light,
+      dark: gradientStops.dark,
+    },
+    tokens,
+  };
+}
+
+function createCorsHeaders(init?: HeadersInit): Headers {
+  const headers = new Headers(init);
+  headers.set("Access-Control-Allow-Origin", "*");
+  return headers;
+}
+
+function createJsonHeaders(status: number): Headers {
+  const headers = createCorsHeaders({
+    "Content-Type": "application/json; charset=utf-8",
+  });
+  headers.set("Cache-Control", status === 200 ? "public, max-age=3600" : "no-store");
+  return headers;
+}
+
+function handleOptions(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}
+
+export async function onRequest({ request }: { request: Request }): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return handleOptions();
+  }
+
+  if (request.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: createJsonHeaders(405),
+    });
+  }
+
+  const url = new URL(request.url);
+  const imageParam = url.searchParams.get("image") ?? url.searchParams.get("url");
+
+  if (!imageParam) {
+    return new Response(JSON.stringify({ error: "Missing image parameter" }), {
+      status: 400,
+      headers: createJsonHeaders(400),
+    });
+  }
+
+  let target: URL;
+  try {
+    target = new URL(imageParam);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid image URL" }), {
+      status: 400,
+      headers: createJsonHeaders(400),
+    });
+  }
+
+  const upstream = await fetch(target.toString(), {
+    cf: {
+      cacheTtl: 3600,
+      cacheEverything: true,
+    },
+  });
+
+  if (!upstream.ok) {
+    return new Response(JSON.stringify({ error: `Upstream request failed with status ${upstream.status}` }), {
+      status: upstream.status,
+      headers: createJsonHeaders(upstream.status),
+    });
+  }
+
+  const contentType = upstream.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("image/")) {
+    return new Response(JSON.stringify({ error: "Unsupported content type" }), {
+      status: 415,
+      headers: createJsonHeaders(415),
+    });
+  }
+
+  const buffer = await upstream.arrayBuffer();
+
+  try {
+    const palette = await buildPalette(buffer, contentType);
+    palette.source = target.toString();
+
+    return new Response(JSON.stringify(palette), {
+      status: 200,
+      headers: createJsonHeaders(200),
+    });
+  } catch (error) {
+    if (error instanceof UnsupportedImageFormatError) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 415,
+        headers: createJsonHeaders(415),
+      });
+    }
+    console.error("Palette generation failed", error);
+    return new Response(JSON.stringify({ error: "Failed to analyze image" }), {
+      status: 500,
+      headers: createJsonHeaders(500),
+    });
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -1642,6 +1642,22 @@
         qualityLabel: document.getElementById("qualityLabel"),
     };
 
+    const PLACEHOLDER_HTML = `<div class="placeholder"><i class="fas fa-music"></i></div>`;
+    const paletteCache = new Map();
+    const themeDefaults = {
+        light: {
+            gradient: "",
+            primaryColor: "",
+            primaryColorDark: "",
+        },
+        dark: {
+            gradient: "",
+            primaryColor: "",
+            primaryColorDark: "",
+        }
+    };
+    let paletteRequestId = 0;
+
     function safeGetLocalStorage(key) {
         try {
             return localStorage.getItem(key);
@@ -1908,7 +1924,148 @@
         sourceMenuOpen: false,
         userScrolledLyrics: false, // 新增：用户是否手动滚动歌词
         lyricsScrollTimeout: null, // 新增：歌词滚动超时
+        themeDefaultsCaptured: false,
+        dynamicPalette: null,
+        currentPaletteImage: null,
     };
+
+    function captureThemeDefaults() {
+        if (state.themeDefaultsCaptured) {
+            return;
+        }
+
+        const initialIsDark = document.body.classList.contains("dark-mode");
+        document.body.classList.remove("dark-mode");
+        const lightStyles = getComputedStyle(document.body);
+        themeDefaults.light.gradient = lightStyles.getPropertyValue("--bg-gradient").trim();
+        themeDefaults.light.primaryColor = lightStyles.getPropertyValue("--primary-color").trim();
+        themeDefaults.light.primaryColorDark = lightStyles.getPropertyValue("--primary-color-dark").trim();
+
+        document.body.classList.add("dark-mode");
+        const darkStyles = getComputedStyle(document.body);
+        themeDefaults.dark.gradient = darkStyles.getPropertyValue("--bg-gradient").trim();
+        themeDefaults.dark.primaryColor = darkStyles.getPropertyValue("--primary-color").trim();
+        themeDefaults.dark.primaryColorDark = darkStyles.getPropertyValue("--primary-color-dark").trim();
+
+        if (!initialIsDark) {
+            document.body.classList.remove("dark-mode");
+        }
+
+        state.themeDefaultsCaptured = true;
+    }
+
+    function applyThemeTokens(tokens) {
+        if (!tokens) return;
+        if (tokens.primaryColor) {
+            document.documentElement.style.setProperty("--primary-color", tokens.primaryColor);
+        }
+        if (tokens.primaryColorDark) {
+            document.documentElement.style.setProperty("--primary-color-dark", tokens.primaryColorDark);
+        }
+    }
+
+    function applyDynamicGradient() {
+        if (!state.themeDefaultsCaptured) {
+            captureThemeDefaults();
+        }
+        const isDark = document.body.classList.contains("dark-mode");
+        const mode = isDark ? "dark" : "light";
+        const defaults = themeDefaults[mode];
+
+        if (defaults.gradient) {
+            document.documentElement.style.setProperty("--bg-gradient", defaults.gradient);
+        } else {
+            document.documentElement.style.removeProperty("--bg-gradient");
+        }
+        applyThemeTokens(defaults);
+
+        const palette = state.dynamicPalette;
+        if (palette && palette.gradients && palette.gradients[mode]) {
+            const gradientInfo = palette.gradients[mode];
+            if (gradientInfo && gradientInfo.gradient) {
+                document.documentElement.style.setProperty("--bg-gradient", gradientInfo.gradient);
+            }
+            if (palette.tokens && palette.tokens[mode]) {
+                applyThemeTokens(palette.tokens[mode]);
+            }
+        }
+    }
+
+    function resetDynamicBackground() {
+        paletteRequestId += 1;
+        state.dynamicPalette = null;
+        state.currentPaletteImage = null;
+        applyDynamicGradient();
+    }
+
+    function showAlbumCoverPlaceholder() {
+        dom.albumCover.innerHTML = PLACEHOLDER_HTML;
+        dom.albumCover.classList.remove("loading");
+        resetDynamicBackground();
+    }
+
+    function setAlbumCoverImage(url) {
+        dom.albumCover.innerHTML = `<img src="${url}" alt="专辑封面">`;
+        dom.albumCover.classList.remove("loading");
+    }
+
+    async function fetchPaletteData(imageUrl) {
+        if (paletteCache.has(imageUrl)) {
+            return paletteCache.get(imageUrl);
+        }
+
+        const response = await fetch(`/palette?image=${encodeURIComponent(imageUrl)}`);
+        const raw = await response.text();
+        let payload = null;
+        try {
+            payload = raw ? JSON.parse(raw) : null;
+        } catch (parseError) {
+            console.warn("解析调色板响应失败:", parseError);
+        }
+
+        if (!response.ok) {
+            const detail = payload && payload.error ? ` (${payload.error})` : "";
+            throw new Error(`Palette request failed: ${response.status}${detail}`);
+        }
+
+        if (payload === null) {
+            throw new Error("Palette response missing body");
+        }
+
+        const data = payload;
+        paletteCache.set(imageUrl, data);
+        return data;
+    }
+
+    async function updateDynamicBackground(imageUrl) {
+        paletteRequestId += 1;
+        const requestId = paletteRequestId;
+
+        if (!imageUrl) {
+            resetDynamicBackground();
+            return;
+        }
+
+        if (state.currentPaletteImage === imageUrl && state.dynamicPalette) {
+            applyDynamicGradient();
+            return;
+        }
+
+        try {
+            const palette = await fetchPaletteData(imageUrl);
+            if (requestId !== paletteRequestId) {
+                return;
+            }
+            state.dynamicPalette = palette;
+            state.currentPaletteImage = imageUrl;
+            applyDynamicGradient();
+        } catch (error) {
+            console.warn("获取动态背景失败:", error);
+            if (requestId === paletteRequestId) {
+                resetDynamicBackground();
+            }
+        }
+    }
 
     function savePlayerState() {
         safeSetLocalStorage("playlistSongs", JSON.stringify(state.playlistSongs));
@@ -2494,13 +2651,18 @@
 
     function setupInteractions() {
         function applyTheme(isDark) {
+            if (!state.themeDefaultsCaptured) {
+                captureThemeDefaults();
+            }
             document.body.classList.toggle("dark-mode", isDark);
             dom.themeToggleButton.classList.toggle("is-dark", isDark);
             const label = isDark ? "切换为浅色模式" : "切换为深色模式";
             dom.themeToggleButton.setAttribute("aria-label", label);
             dom.themeToggleButton.setAttribute("title", label);
+            applyDynamicGradient();
         }
 
+        captureThemeDefaults();
         const savedTheme = safeGetLocalStorage("theme");
         const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
         const initialIsDark = savedTheme ? savedTheme === "dark" : prefersDark;
@@ -2710,34 +2872,32 @@
             try {
                 dom.albumCover.classList.add("loading");
                 const picUrl = API.getPicUrl(song);
-                
+
                 // 修复：直接使用JSONP请求获取封面数据
                 const data = await API.fetchJson(picUrl);
-                
+
                 if (data && data.url) {
                     // 预加载图片以确保加载成功
                     const img = new Image();
+                    const imageUrl = preferHttpsUrl(data.url);
+                    img.crossOrigin = "anonymous";
                     img.onload = () => {
-                        dom.albumCover.innerHTML = `<img src="${data.url}" alt="专辑封面">`;
-                        dom.albumCover.classList.remove("loading");
+                        setAlbumCoverImage(imageUrl);
+                        updateDynamicBackground(imageUrl);
                     };
                     img.onerror = () => {
-                        dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-                        dom.albumCover.classList.remove("loading");
+                        showAlbumCoverPlaceholder();
                     };
-                    img.src = data.url;
+                    img.src = imageUrl;
                 } else {
-                    dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-                    dom.albumCover.classList.remove("loading");
+                    showAlbumCoverPlaceholder();
                 }
             } catch (error) {
                 console.error("加载封面失败:", error);
-                dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-                dom.albumCover.classList.remove("loading");
+                showAlbumCoverPlaceholder();
             }
         } else {
-            dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
-            dom.albumCover.classList.remove("loading");
+            showAlbumCoverPlaceholder();
         }
     }
     
@@ -3072,7 +3232,7 @@
                 updateProgressBarBackground(0, 1);
                 dom.currentSongTitle.textContent = "选择一首歌曲开始播放";
                 dom.currentSongArtist.textContent = "未知艺术家";
-                dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
+                showAlbumCoverPlaceholder();
                 dom.lyrics.innerHTML = "";
                 dom.lyrics.classList.add("empty");
                 updatePlayPauseButton();
@@ -3130,7 +3290,7 @@
             updateProgressBarBackground(0, 1);
             dom.currentSongTitle.textContent = "选择一首歌曲开始播放";
             dom.currentSongArtist.textContent = "未知艺术家";
-            dom.albumCover.innerHTML = "<div class=\"placeholder\"><i class=\"fas fa-music\"></i></div>";
+            showAlbumCoverPlaceholder();
             dom.lyrics.innerHTML = "";
             dom.lyrics.classList.add("empty");
             updatePlayPauseButton();


### PR DESCRIPTION
## Summary
- vendor a JPEG decoder and resample logic so the palette Cloudflare function no longer depends on browser-only canvas APIs
- keep the palette API resilient by catching unsupported formats and returning structured JSON errors
- update the client palette fetcher to surface response details while maintaining caching

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2c97691cc832b9d8ca08bf18c4b28