### PR TITLE
Fix lyrics pane horizontal scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,6 +844,7 @@
             flex: 1;
             width: 100%;
             overflow-y: auto;
+            overflow-x: hidden;
             display: flex;
             flex-direction: column;
             align-items: center;


### PR DESCRIPTION
## Summary
- prevent the lyrics scroll container from exposing a horizontal scrollbar by hiding horizontal overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e40bbbc7b8832bb475502832ede201