### PR TITLE
Refine mobile search layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -89,7 +89,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 100vh;
+    min-height: 100dvh;
     margin: 0;
     padding: 20px;
     box-sizing: border-box;
@@ -131,7 +131,7 @@ body.background-transitioning .background-stage__layer--transition {
 
 /* 16:9 容器布局 */
 .container {
-    max-width: 1200px;
+    width: min(1200px, 100%);
     margin: 0 auto;
     background: var(--container-bg);
     border-radius: 24px;
@@ -196,6 +196,12 @@ body.background-transitioning .background-stage__layer--transition {
     overflow: visible;
     display: flex;
     flex-direction: column;
+}
+
+.search-area *,
+.search-area *::before,
+.search-area *::after {
+    box-sizing: border-box;
 }
 
 /* 搜索模式下的搜索区域 */
@@ -1448,13 +1454,17 @@ input[type="range"]:active::-moz-range-thumb {
 }
 
 @media (max-width: 768px) {
-    body { 
-        padding: 0; 
+    body {
+        justify-content: flex-start;
+        align-items: stretch;
+        flex-direction: column;
+        padding: env(safe-area-inset-top) clamp(16px, 4vw, 24px) calc(16px + env(safe-area-inset-bottom));
+        background-color: #0f0f0f;
     }
     .container {
-        padding: 15px;
-        gap: 15px;
-        grid-template-areas: 
+        padding: clamp(16px, 4vw, 24px);
+        gap: clamp(12px, 3vw, 18px);
+        grid-template-areas:
             "header"
             "search"
             "cover"
@@ -1462,40 +1472,115 @@ input[type="range"]:active::-moz-range-thumb {
             "playlist"
             "controls";
         grid-template-columns: 1fr;
-        grid-template-rows: auto auto auto auto 1fr auto;
-        border-radius: 0;
-        border: none;
-        height: 100vh;
+        grid-template-rows: auto auto auto auto minmax(0, 1fr) auto;
+        border-radius: 20px;
+        border: 1px solid var(--border-color);
+        height: auto;
         max-height: none;
+        min-height: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+        backdrop-filter: blur(var(--backdrop-blur));
         aspect-ratio: auto;
+        overflow: hidden;
     }
 
     .container.search-mode {
-        grid-template-areas: 
+        grid-template-areas:
             "header"
             "search"
             "search"
             "controls";
-        grid-template-rows: auto auto 1fr auto;
+        grid-template-rows: auto auto minmax(0, 1fr) auto;
     }
 
-    .header h1 { 
-        font-size: 1.8em; 
+    .header h1 {
+        font-size: 1.8em;
     }
-    .search-area { 
-        padding: 15px; 
+    .header .warning {
+        font-size: 0.75em;
+        line-height: 1.4;
     }
-    .search-container { 
-        flex-direction: column; 
-        gap: 10px; 
+    .search-area {
+        padding: 0;
+        background: transparent;
+        border: none;
     }
-    .search-input, .search-btn, .source-select-wrapper {
+    .search-container {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        grid-auto-rows: auto;
+        gap: 6px 12px;
+        padding: clamp(12px, 4vw, 16px);
+        border-radius: 20px;
+        border: 1px solid rgba(255, 255, 255, 0.65);
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.78));
+        box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+        align-items: center;
+        position: relative;
+    }
+    .search-container::before {
+        content: "\f002";
+        font-family: "Font Awesome 6 Free";
+        font-weight: 900;
+        font-size: 1rem;
+        color: var(--text-secondary-color);
+        padding-left: 2px;
+    }
+    .search-input {
+        grid-column: 2 / 3;
+        width: 100%;
+        background: transparent;
+        border: none;
+        padding: 10px 0 10px 4px;
+        font-size: 1.05rem;
+    }
+    .search-input::placeholder {
+        color: rgba(127, 140, 141, 0.85);
+    }
+    .source-select-wrapper,
+    .search-btn {
+        grid-column: 1 / -1;
         width: 100%;
     }
-
     .source-select-btn {
         width: 100%;
         justify-content: space-between;
+        border-radius: 14px;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        background: rgba(255, 255, 255, 0.85);
+        padding: 12px 16px;
+        box-shadow: none;
+    }
+    .source-select-btn:focus-visible {
+        box-shadow: 0 0 0 3px rgba(26, 188, 156, 0.18);
+    }
+    .source-select-btn:hover,
+    .source-select-btn.active {
+        box-shadow: 0 0 0 2px rgba(26, 188, 156, 0.12);
+    }
+    .search-btn {
+        border-radius: 14px;
+        padding: 14px 18px;
+        font-size: 1rem;
+        justify-content: center;
+        gap: 10px;
+    }
+
+    .dark-mode .search-container {
+        border: 1px solid rgba(26, 188, 156, 0.2);
+        background: linear-gradient(135deg, rgba(12, 28, 26, 0.92), rgba(11, 24, 22, 0.8));
+        box-shadow: 0 18px 44px rgba(0, 0, 0, 0.36);
+    }
+    .dark-mode .search-container::before {
+        color: rgba(236, 240, 241, 0.72);
+    }
+    .dark-mode .source-select-btn {
+        border: 1px solid rgba(26, 188, 156, 0.28);
+        background: rgba(9, 20, 19, 0.94);
+        color: #ecf0f1;
+    }
+    .dark-mode .source-select-btn:hover,
+    .dark-mode .source-select-btn.active {
+        box-shadow: 0 0 0 2px rgba(26, 188, 156, 0.25);
     }
 
     .cover-area {
@@ -1533,29 +1618,49 @@ input[type="range"]:active::-moz-range-thumb {
         color: white; 
     }
 
-    .playlist, .lyrics { 
-        display: none; 
-        height: 100%; 
+    .playlist, .lyrics {
+        display: none;
+        min-height: 240px;
+        background: var(--component-bg);
+        border-radius: 16px;
+        border: 1px solid var(--border-color);
+        padding: 12px;
     }
-    .playlist.active, .lyrics.active { 
-        display: block; 
+    .playlist.active, .lyrics.active {
+        display: block;
     }
 
     .controls {
-        gap: 15px;
+        gap: 12px;
+        padding: 12px clamp(14px, 4vw, 22px);
+        margin: 0 calc(-1 * clamp(16px, 4vw, 24px)) calc(-1 * clamp(16px, 4vw, 24px));
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.65));
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        border-top: 1px solid rgba(255, 255, 255, 0.4);
+        border-radius: 20px 20px 0 0;
+        position: sticky;
+        bottom: calc(env(safe-area-inset-bottom) * -1);
+        box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.12);
     }
     .transport-controls {
         width: 100%;
         justify-content: center;
+        gap: clamp(18px, 6vw, 28px);
     }
     .progress-container {
         flex: 1 1 100%;
         min-width: 100%;
+        order: 3;
+        gap: 8px;
+        padding: 0 4px;
     }
     .audio-tools {
         width: 100%;
-        justify-content: space-between;
-        gap: 12px;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 10px;
+        order: 4;
     }
     .volume-container {
         flex: 1;
@@ -1563,5 +1668,76 @@ input[type="range"]:active::-moz-range-thumb {
     }
     .volume-container input[type="range"] {
         width: 100%;
+    }
+}
+
+@media (max-width: 768px) {
+    .controls button,
+    .play-mode-btn {
+        width: 48px;
+        height: 48px;
+        font-size: 1.1em;
+        box-shadow: none;
+    }
+
+    .player-quality {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+    }
+
+    .player-quality-btn {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 520px) {
+    .header h1 {
+        font-size: clamp(1.4rem, 6vw, 1.8rem);
+    }
+
+    .search-container {
+        gap: 10px 12px;
+    }
+
+    .album-cover {
+        width: clamp(120px, 48vw, 180px);
+        height: clamp(120px, 48vw, 180px);
+    }
+
+    .current-song-info {
+        gap: 6px;
+    }
+
+    .view-toggle {
+        position: sticky;
+        top: calc(env(safe-area-inset-top) + clamp(16px, 4vw, 24px));
+        z-index: 20;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
+        border-radius: 12px;
+        padding: 6px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    }
+
+    .playlist, .lyrics {
+        min-height: 220px;
+        padding: 10px;
+    }
+
+    .controls {
+        padding-bottom: calc(16px + env(safe-area-inset-bottom));
+    }
+
+    .progress-container span {
+        font-size: 0.9em;
+    }
+
+    .transport-controls button,
+    .play-mode-btn,
+    .controls button {
+        width: 44px;
+        height: 44px;
+        font-size: 1em;
     }
 }


### PR DESCRIPTION
## Summary
- ensure all elements in the search block respect container boundaries with localized box-sizing rules
- redesign the portrait mobile search card with balanced spacing, built-in iconography, and dark-mode polish inspired by mainstream music apps
- stack the search action and source selector cleanly on phones without altering desktop presentation

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68e55bc8eb50832b9ccabcf9b91bc969