### PR TITLE
Polish mobile vinyl view and controls

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -1,0 +1,655 @@
+/* Mobile-specific layout inspired by a dedicated music player interface */
+
+html.mobile-view,
+body.mobile-view {
+    background: radial-gradient(120% 140% at 50% 0%, #1b1d24 0%, #0d1018 70%, #05070c 100%);
+    color: #f2f5f9;
+}
+
+body.mobile-view {
+    margin: 0;
+    min-height: 100dvh;
+    display: flex;
+    justify-content: center;
+    align-items: stretch;
+    padding: calc(env(safe-area-inset-top) + 12px) clamp(12px, 5vw, 24px) calc(env(safe-area-inset-bottom) + 20px);
+    font-family: var(--font-main);
+    background-attachment: fixed;
+}
+
+body.mobile-view .background-stage {
+    display: none;
+}
+
+body.mobile-view .container {
+    width: 100%;
+    max-width: 420px;
+    background: linear-gradient(180deg, rgba(27, 29, 36, 0.92), rgba(7, 9, 14, 0.95));
+    border-radius: 32px;
+    padding: clamp(16px, 5vw, 28px);
+    padding-top: calc(env(safe-area-inset-top) + clamp(18px, 6vw, 32px));
+    padding-bottom: calc(env(safe-area-inset-bottom) + clamp(22px, 7vw, 32px));
+    box-shadow: 0 32px 90px rgba(0, 0, 0, 0.65);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(12px, 4vw, 24px);
+    position: relative;
+    overflow: hidden;
+}
+
+body.mobile-view .container::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(100% 100% at 50% 0%, rgba(255, 255, 255, 0.08) 0%, transparent 65%);
+    opacity: 0.6;
+}
+
+body.mobile-view .header,
+body.mobile-view .theme-switch-wrapper,
+body.mobile-view .warning {
+    display: none !important;
+}
+
+body.mobile-view .mobile-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: clamp(4px, 3vw, 12px);
+    z-index: 2;
+}
+
+body.mobile-view .mobile-toolbar__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #ffffff;
+    letter-spacing: 0.04em;
+    text-align: center;
+}
+
+body.mobile-view .mobile-toolbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+body.mobile-view .mobile-toolbar__button {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: #f5f7fa;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(8px);
+    transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+body.mobile-view .mobile-toolbar__button:active,
+body.mobile-view .mobile-toolbar__button:focus-visible,
+body.mobile-view .mobile-toolbar__button:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.28);
+}
+
+body.mobile-view .main-content {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(18px, 6vw, 32px);
+    z-index: 1;
+}
+
+body.mobile-view .cover-area {
+    background: transparent;
+    border: none;
+    padding: 0;
+    align-items: center;
+    text-align: center;
+    gap: clamp(16px, 4vw, 24px);
+}
+
+body.mobile-view .mobile-turntable {
+    margin-bottom: 0;
+    position: relative;
+    display: flex;
+    justify-content: center;
+}
+
+body.mobile-view .mobile-turntable__platter {
+    width: min(78vw, 320px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: radial-gradient(circle at 48% 50%, #1a1d25 0%, #05070c 65%, #000 100%);
+    box-shadow: 0 32px 70px rgba(0, 0, 0, 0.55);
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    animation: mobile-turntable-spin 18s linear infinite;
+    animation-play-state: paused;
+}
+
+body.mobile-view .mobile-turntable__platter::before {
+    content: "";
+    position: absolute;
+    inset: 6%;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 10%, transparent 45%),
+        conic-gradient(from 90deg, rgba(255, 255, 255, 0.12) 0deg, transparent 45deg, transparent 180deg, rgba(255, 255, 255, 0.08) 225deg, transparent 360deg),
+        radial-gradient(circle at 48% 45%, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.02) 35%, transparent 60%);
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+body.mobile-view .mobile-turntable__label {
+    display: block;
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: 14%;
+    aspect-ratio: 1 / 1;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: radial-gradient(circle at 50% 50%, rgba(245, 245, 245, 0.9) 0%, #b5b9c3 55%, #3d4048 100%);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.35), inset 0 0 8px rgba(0, 0, 0, 0.45);
+    z-index: 3;
+}
+
+body.mobile-view .album-cover {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 58%;
+    aspect-ratio: 1 / 1;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    overflow: hidden;
+    box-shadow:
+        inset 0 0 0 3px rgba(0, 0, 0, 0.55),
+        0 18px 38px rgba(0, 0, 0, 0.45);
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 2;
+}
+
+body.mobile-view .album-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+body.mobile-view .album-cover .placeholder {
+    font-size: clamp(36px, 12vw, 48px);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+body.mobile-view .album-cover::after {
+    content: "";
+    position: absolute;
+    inset: 18%;
+    border-radius: 50%;
+    box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.28), inset 0 0 0 2px rgba(255, 255, 255, 0.12);
+    background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.08) 0%, rgba(0, 0, 0, 0.18) 65%, rgba(0, 0, 0, 0.28) 100%);
+    pointer-events: none;
+}
+
+body.mobile-view.is-playing .mobile-turntable__platter {
+    animation-play-state: running;
+}
+
+@keyframes mobile-turntable-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+body.mobile-view .current-song-info {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+body.mobile-view .current-song-title {
+    font-size: clamp(1.05rem, 5vw, 1.32rem);
+    font-weight: 600;
+    color: #ffffff;
+    letter-spacing: 0.02em;
+}
+
+body.mobile-view .current-song-artist {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+body.mobile-view .mobile-quality-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 18px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 0.85rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    margin: 8px auto 0;
+    cursor: pointer;
+    transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease, transform 0.2s ease;
+}
+
+body.mobile-view .mobile-quality-chip i {
+    font-size: 0.75rem;
+    opacity: 0.85;
+}
+
+body.mobile-view .mobile-quality-chip:focus-visible,
+body.mobile-view .mobile-quality-chip:hover {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.32);
+    color: #ffffff;
+}
+
+body.mobile-view .mobile-quality-chip.active {
+    background: linear-gradient(135deg, rgba(243, 109, 109, 0.95), rgba(243, 162, 91, 0.95));
+    border-color: transparent;
+    color: #1b1d24;
+    transform: translateY(-1px);
+    box-shadow: 0 14px 32px rgba(243, 109, 109, 0.35);
+}
+
+body.mobile-view .controls {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    margin: 0;
+    padding: 0;
+    gap: clamp(16px, 5vw, 24px);
+    align-items: stretch;
+}
+
+body.mobile-view .progress-container {
+    order: 1;
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    row-gap: 8px;
+    column-gap: 10px;
+    align-items: center;
+}
+
+body.mobile-view .progress-container input[type="range"] {
+    grid-column: 1 / span 3;
+    grid-row: 1;
+    width: 100%;
+    height: 4px;
+    border-radius: 999px;
+    background: linear-gradient(to right,
+        rgba(243, 162, 91, 0.95) 0%,
+        rgba(243, 162, 91, 0.95) var(--progress, 0%),
+        rgba(255, 255, 255, 0.15) var(--progress, 0%),
+        rgba(255, 255, 255, 0.15) 100%);
+}
+
+body.mobile-view .progress-container span {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+body.mobile-view .transport-controls {
+    order: 2;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: clamp(12px, 5vw, 18px);
+}
+
+body.mobile-view .transport-button {
+    width: clamp(46px, 14vw, 54px);
+    height: clamp(46px, 14vw, 54px);
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+    transition: transform 0.25s ease, background 0.25s ease;
+}
+
+body.mobile-view .play-mode-btn {
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+    margin-right: 0;
+}
+
+body.mobile-view .transport-button i {
+    font-size: 1.05rem;
+}
+
+body.mobile-view .transport-button--play {
+    width: clamp(60px, 18vw, 70px);
+    height: clamp(60px, 18vw, 70px);
+    background: linear-gradient(135deg, #f36d6d 0%, #f3a25b 100%);
+    color: #1f1b1d;
+    box-shadow: 0 18px 36px rgba(243, 117, 109, 0.45);
+}
+
+body.mobile-view .transport-button:active {
+    transform: scale(0.94);
+}
+
+body.mobile-view #mobileQueueToggle {
+    display: inline-flex;
+}
+
+body.mobile-view .audio-tools {
+    display: none;
+}
+
+body.mobile-view .player-quality {
+    flex-shrink: 0;
+}
+
+body.mobile-view .player-quality-btn {
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+    border: none;
+    border-radius: 14px;
+    padding: 8px 12px;
+    font-size: 0.85rem;
+}
+
+body.mobile-view .volume-container {
+    display: none;
+}
+
+body.mobile-view input[type="range"]::-webkit-slider-thumb,
+body.mobile-view input[type="range"]::-moz-range-thumb {
+    background: #f3a25b;
+    border-color: rgba(255, 255, 255, 0.85);
+}
+
+body.mobile-view #loadOnlineBtn {
+    order: 5;
+    width: 100%;
+    border-radius: 18px;
+    border: none;
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+    padding: 14px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+body.mobile-view .mobile-overlay-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(4, 6, 10, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.35s ease;
+    z-index: 30;
+}
+
+body.mobile-view.mobile-search-open .mobile-overlay-scrim,
+body.mobile-view.mobile-panel-open .mobile-overlay-scrim {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+body.mobile-view .mobile-panel {
+    position: fixed;
+    left: 50%;
+    transform: translate(-50%, 110%);
+    bottom: 0;
+    width: min(100%, 420px);
+    background: rgba(13, 16, 24, 0.96);
+    backdrop-filter: blur(28px);
+    border-radius: 28px 28px 0 0;
+    padding: 18px clamp(18px, 6vw, 28px) calc(env(safe-area-inset-bottom) + clamp(22px, 7vw, 32px));
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    z-index: 120;
+    pointer-events: auto;
+    box-shadow: 0 -28px 60px rgba(0, 0, 0, 0.6);
+    transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+body.mobile-view.mobile-panel-open .mobile-panel {
+    transform: translate(-50%, 0);
+}
+
+body.mobile-view .mobile-panel-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    column-gap: 12px;
+    color: #ffffff;
+}
+
+body.mobile-view .mobile-panel-handle {
+    grid-column: 1 / -1;
+    width: 56px;
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.28);
+    margin: 0 auto 10px;
+}
+
+body.mobile-view .mobile-panel-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+body.mobile-view .mobile-panel-header .mobile-close-btn {
+    justify-self: end;
+}
+
+body.mobile-view .mobile-close-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+}
+
+body.mobile-view .mobile-close-btn i {
+    pointer-events: none;
+}
+
+body.mobile-view .view-toggle {
+    display: none;
+}
+
+body.mobile-view .view-toggle button {
+    border: none;
+    border-radius: 999px;
+    padding: 10px 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.05em;
+    color: rgba(255, 255, 255, 0.68);
+    background: transparent;
+    transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.mobile-view .view-toggle button.active {
+    background: linear-gradient(135deg, #f36d6d 0%, #f3a25b 100%);
+    color: #1b1d24;
+    box-shadow: 0 12px 30px rgba(243, 109, 109, 0.35);
+}
+
+body.mobile-view .playlist,
+body.mobile-view .lyrics {
+    display: none;
+    flex-direction: column;
+    background: transparent;
+    border: none;
+    padding: 0;
+    max-height: min(50vh, 360px);
+}
+
+body.mobile-view .playlist.active,
+body.mobile-view .lyrics.active {
+    display: flex;
+}
+
+body.mobile-view .playlist-scroll,
+body.mobile-view .lyrics-scroll {
+    max-height: min(50vh, 340px);
+    padding-right: 6px;
+    margin-right: -6px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+body.mobile-view .playlist-items .playlist-item {
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    margin-bottom: 6px;
+    color: #f2f4f7;
+    touch-action: manipulation;
+}
+
+body.mobile-view .playlist-items .playlist-item:hover,
+body.mobile-view .playlist-items .playlist-item.current {
+    background: rgba(243, 162, 91, 0.25);
+    color: #ffffff;
+}
+
+body.mobile-view .lyrics {
+    color: rgba(255, 255, 255, 0.78);
+}
+
+body.mobile-view .lyrics-scroll {
+    overflow-y: auto;
+    scrollbar-width: thin;
+}
+
+body.mobile-view .lyrics-scroll::-webkit-scrollbar {
+    width: 4px;
+}
+
+body.mobile-view .lyrics-scroll::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+}
+
+body.mobile-view .playlist .clear-playlist-btn {
+    display: none;
+}
+
+body.mobile-view .search-area {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(6, 9, 14, 0.95);
+    backdrop-filter: blur(26px);
+    transform: translateY(-100%);
+    transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+    z-index: 70;
+    padding: calc(env(safe-area-inset-top) + 28px) clamp(18px, 6vw, 28px) clamp(env(safe-area-inset-bottom) + 24px, 8vw, 36px);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+body.mobile-view.mobile-search-open .search-area {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+}
+
+body.mobile-view .search-area .mobile-close-btn {
+    align-self: flex-end;
+    margin-right: clamp(18px, 6vw, 28px);
+}
+
+body.mobile-view .search-area .search-container,
+body.mobile-view .search-area .search-results {
+    max-width: min(420px, 100%);
+    margin: 0 auto;
+    width: 100%;
+}
+
+body.mobile-view .search-container {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 18px;
+    padding: 16px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+}
+
+body.mobile-view .search-input {
+    color: #ffffff;
+    width: 100%;
+}
+
+body.mobile-view .search-input::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+body.mobile-view .source-select-wrapper,
+body.mobile-view .search-btn {
+    width: 100%;
+}
+
+body.mobile-view .source-select-btn,
+body.mobile-view .search-btn {
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
+    border: none;
+}
+
+body.mobile-view .search-btn {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+}
+
+body.mobile-view .search-results {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    width: 100%;
+}
+
+body.mobile-view #notification {
+    top: 18px;
+    left: 50%;
+    transform: translate(-50%, -120%);
+}
+
+body.mobile-view #notification.show {
+    transform: translate(-50%, 0);
+}
+
+body.mobile-view .debug-info {
+    display: none;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -535,6 +535,8 @@ body.background-transitioning .background-stage__layer--transition {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
+    gap: 16px;
     text-align: center;
     box-sizing: border-box;
     height: 100%;
@@ -545,7 +547,9 @@ body.background-transitioning .background-stage__layer--transition {
 .album-cover {
     width: 200px;
     height: auto;
-    flex-grow: 1;
+    min-height: 200px;
+    flex-grow: 0;
+    flex-shrink: 0;
     border-radius: 12px;
     background: linear-gradient(45deg, var(--primary-color), var(--success-color));
     display: flex;
@@ -942,6 +946,14 @@ body.background-transitioning .background-stage__layer--transition {
     display: flex;
     align-items: center;
     gap: 12px;
+}
+
+html:not(.mobile-view) #playModeBtn {
+    margin-right: 8px;
+}
+
+#mobileQueueToggle {
+    display: none;
 }
 
 #playPauseBtn {
@@ -1408,336 +1420,41 @@ input[type="range"]:active::-moz-range-thumb {
     background: #f39c12;
 }
 
-/* 视图切换按钮 - 桌面端隐藏，移动端显示 */
-.view-toggle { 
+/* 视图切换按钮 - 桌面端隐藏 */
+.view-toggle {
     display: none;
 }
 
-/* 移动端适配 */
-@media (max-width: 1024px) {
-    .container {
-        grid-template-areas: 
-            "header header"
-            "search search"
-            "cover cover"
-            "playlist lyrics"
-            "controls controls";
-        grid-template-columns: 1fr 1fr;
-        grid-template-rows: auto auto auto 1fr auto;
-        aspect-ratio: auto;
-        height: 90vh;
-    }
-
-    .container.search-mode {
-        grid-template-areas: 
-            "header header"
-            "search search"
-            "search search"
-            "controls controls";
-    }
-
-    .cover-area {
-        flex-direction: row;
-        gap: 20px;
-    }
-
-    .album-cover {
-        width: 120px;
-        height: 120px;
-        margin-bottom: 0;
-    }
-
-    .current-song-info {
-        flex: 1;
-        text-align: left;
-    }
+/* 新增：移动端结构在桌面端的默认表现 */
+.mobile-status-bar,
+.mobile-toolbar,
+.mobile-panel-header,
+.mobile-overlay-scrim,
+.mobile-quality-chip,
+.mobile-close-btn,
+.mobile-turntable__tonearm,
+.mobile-turntable__label {
+    display: none;
 }
 
-@media (max-width: 768px) {
-    body {
-        justify-content: flex-start;
-        align-items: stretch;
-        flex-direction: column;
-        padding: env(safe-area-inset-top) clamp(16px, 4vw, 24px) calc(16px + env(safe-area-inset-bottom));
-        background-color: #0f0f0f;
-    }
-    .container {
-        padding: clamp(16px, 4vw, 24px);
-        gap: clamp(12px, 3vw, 18px);
-        grid-template-areas:
-            "header"
-            "search"
-            "cover"
-            "view-toggle"
-            "playlist"
-            "controls";
-        grid-template-columns: 1fr;
-        grid-template-rows: auto auto auto auto minmax(0, 1fr) auto;
-        border-radius: 20px;
-        border: 1px solid var(--border-color);
-        height: auto;
-        max-height: none;
-        min-height: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-        backdrop-filter: blur(var(--backdrop-blur));
-        aspect-ratio: auto;
-        overflow: hidden;
-    }
-
-    .container.search-mode {
-        grid-template-areas:
-            "header"
-            "search"
-            "search"
-            "controls";
-        grid-template-rows: auto auto minmax(0, 1fr) auto;
-    }
-
-    .header h1 {
-        font-size: 1.8em;
-    }
-    .header .warning {
-        font-size: 0.75em;
-        line-height: 1.4;
-    }
-    .search-area {
-        padding: 0;
-        background: transparent;
-        border: none;
-    }
-    .search-container {
-        display: grid;
-        grid-template-columns: auto minmax(0, 1fr);
-        grid-auto-rows: auto;
-        gap: 6px 12px;
-        padding: clamp(12px, 4vw, 16px);
-        border-radius: 20px;
-        border: 1px solid rgba(255, 255, 255, 0.65);
-        background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.78));
-        box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
-        align-items: center;
-        position: relative;
-    }
-    .search-container::before {
-        content: "\f002";
-        font-family: "Font Awesome 6 Free";
-        font-weight: 900;
-        font-size: 1rem;
-        color: var(--text-secondary-color);
-        padding-left: 2px;
-    }
-    .search-input {
-        grid-column: 2 / 3;
-        width: 100%;
-        background: transparent;
-        border: none;
-        padding: 10px 0 10px 4px;
-        font-size: 1.05rem;
-    }
-    .search-input::placeholder {
-        color: rgba(127, 140, 141, 0.85);
-    }
-    .source-select-wrapper,
-    .search-btn {
-        grid-column: 1 / -1;
-        width: 100%;
-    }
-    .source-select-btn {
-        width: 100%;
-        justify-content: space-between;
-        border-radius: 14px;
-        border: 1px solid rgba(15, 23, 42, 0.08);
-        background: rgba(255, 255, 255, 0.85);
-        padding: 12px 16px;
-        box-shadow: none;
-    }
-    .source-select-btn:focus-visible {
-        box-shadow: 0 0 0 3px rgba(26, 188, 156, 0.18);
-    }
-    .source-select-btn:hover,
-    .source-select-btn.active {
-        box-shadow: 0 0 0 2px rgba(26, 188, 156, 0.12);
-    }
-    .search-btn {
-        border-radius: 14px;
-        padding: 14px 18px;
-        font-size: 1rem;
-        justify-content: center;
-        gap: 10px;
-    }
-
-    .dark-mode .search-container {
-        border: 1px solid rgba(26, 188, 156, 0.2);
-        background: linear-gradient(135deg, rgba(12, 28, 26, 0.92), rgba(11, 24, 22, 0.8));
-        box-shadow: 0 18px 44px rgba(0, 0, 0, 0.36);
-    }
-    .dark-mode .search-container::before {
-        color: rgba(236, 240, 241, 0.72);
-    }
-    .dark-mode .source-select-btn {
-        border: 1px solid rgba(26, 188, 156, 0.28);
-        background: rgba(9, 20, 19, 0.94);
-        color: #ecf0f1;
-    }
-    .dark-mode .source-select-btn:hover,
-    .dark-mode .source-select-btn.active {
-        box-shadow: 0 0 0 2px rgba(26, 188, 156, 0.25);
-    }
-
-    .cover-area {
-        flex-direction: column;
-        padding: 15px;
-    }
-
-    .album-cover {
-        width: 150px;
-        height: 150px;
-        margin-bottom: 15px;
-    }
-
-    .current-song-info {
-        text-align: center;
-    }
-
-    .view-toggle { 
-        grid-area: view-toggle;
-        display: flex; 
-        gap: 10px; 
-    }
-    .view-toggle button { 
-        flex: 1; 
-        padding: 10px; 
-        border: 2px solid var(--primary-color); 
-        background: var(--component-bg); 
-        color: var(--primary-color); 
-        border-radius: 8px; 
-        cursor: pointer; 
-        transition: all 0.2s ease; 
-    }
-    .view-toggle button.active { 
-        background: var(--primary-color); 
-        color: white; 
-    }
-
-    .playlist, .lyrics {
-        display: none;
-        min-height: 240px;
-        background: var(--component-bg);
-        border-radius: 16px;
-        border: 1px solid var(--border-color);
-        padding: 12px;
-    }
-    .playlist.active, .lyrics.active {
-        display: block;
-    }
-
-    .controls {
-        gap: 12px;
-        padding: 12px clamp(14px, 4vw, 22px);
-        margin: 0 calc(-1 * clamp(16px, 4vw, 24px)) calc(-1 * clamp(16px, 4vw, 24px));
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.65));
-        backdrop-filter: blur(18px);
-        -webkit-backdrop-filter: blur(18px);
-        border-top: 1px solid rgba(255, 255, 255, 0.4);
-        border-radius: 20px 20px 0 0;
-        position: sticky;
-        bottom: calc(env(safe-area-inset-bottom) * -1);
-        box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.12);
-    }
-    .transport-controls {
-        width: 100%;
-        justify-content: center;
-        gap: clamp(18px, 6vw, 28px);
-    }
-    .progress-container {
-        flex: 1 1 100%;
-        min-width: 100%;
-        order: 3;
-        gap: 8px;
-        padding: 0 4px;
-    }
-    .audio-tools {
-        width: 100%;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: 10px;
-        order: 4;
-    }
-    .volume-container {
-        flex: 1;
-        min-width: 0;
-    }
-    .volume-container input[type="range"] {
-        width: 100%;
-    }
+.mobile-panel {
+    display: contents;
 }
 
-@media (max-width: 768px) {
-    .controls button,
-    .play-mode-btn {
-        width: 48px;
-        height: 48px;
-        font-size: 1.1em;
-        box-shadow: none;
-    }
-
-    .player-quality {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-    }
-
-    .player-quality-btn {
-        width: 100%;
-        justify-content: center;
-    }
+.mobile-turntable {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    margin-bottom: 15px;
 }
 
-@media (max-width: 520px) {
-    .header h1 {
-        font-size: clamp(1.4rem, 6vw, 1.8rem);
-    }
-
-    .search-container {
-        gap: 10px 12px;
-    }
-
-    .album-cover {
-        width: clamp(120px, 48vw, 180px);
-        height: clamp(120px, 48vw, 180px);
-    }
-
-    .current-song-info {
-        gap: 6px;
-    }
-
-    .view-toggle {
-        position: sticky;
-        top: calc(env(safe-area-inset-top) + clamp(16px, 4vw, 24px));
-        z-index: 20;
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
-        border-radius: 12px;
-        padding: 6px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
-    }
-
-    .playlist, .lyrics {
-        min-height: 220px;
-        padding: 10px;
-    }
-
-    .controls {
-        padding-bottom: calc(16px + env(safe-area-inset-bottom));
-    }
-
-    .progress-container span {
-        font-size: 0.9em;
-    }
-
-    .transport-controls button,
-    .play-mode-btn,
-    .controls button {
-        width: 44px;
-        height: 44px;
-        font-size: 1em;
-    }
+.mobile-turntable__platter {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    max-width: 220px;
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,34 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link rel="stylesheet" href="css/style.css">
-
+    <script>
+        (function () {
+            const ua = navigator.userAgent || "";
+            const isMobileUA = /android|iphone|ipad|ipod|mobile|blackberry|phone|opera mini|windows phone/i.test(ua);
+            const isSmallScreen = typeof window.matchMedia === "function" && window.matchMedia("(max-width: 820px)").matches;
+            const isMobile = isMobileUA || isSmallScreen;
+            window.__SOLARA_IS_MOBILE = isMobile;
+            if (!isMobile) {
+                return;
+            }
+            document.documentElement.classList.add("mobile-view");
+            const link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.href = "css/mobile.css";
+            link.id = "mobileStylesheet";
+            document.head.appendChild(link);
+            const applyBodyClass = () => {
+                if (document.body) {
+                    document.body.classList.add("mobile-view");
+                }
+            };
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", applyBodyClass, { once: true });
+            } else {
+                applyBodyClass();
+            }
+        })();
+    </script>
 </head>
 <body>
     <div class="background-stage" id="backgroundStage" aria-hidden="true">
@@ -17,104 +44,137 @@
         <div class="background-stage__layer background-stage__layer--transition" id="backgroundTransitionLayer"></div>
     </div>
     <div class="container" id="mainContainer">
-    <div class="header">
-        <h1>Solara</h1>
-        <div class="warning">Made by Wet Dream Boy，免费API来自GD音乐台(music.gdstudio.xyz)，仅供学习交流使用，请支持正版音乐奥！</div>
-        <div class="theme-switch-wrapper">
-            <button id="themeToggleButton" class="theme-toggle-button" type="button" aria-label="切换深浅色模式">
-                <i class="fas fa-sun theme-icon theme-icon--sun" aria-hidden="true"></i>
-                <i class="fas fa-moon theme-icon theme-icon--moon" aria-hidden="true"></i>
+        <div class="mobile-toolbar" id="mobileToolbar" role="toolbar">
+            <button class="mobile-toolbar__button" id="mobileBackButton" type="button" aria-label="收起面板">
+                <i class="fas fa-chevron-down" aria-hidden="true"></i>
             </button>
-        </div>
-    </div>
-
-    <div class="search-area">
-        <div class="search-container">
-            <input type="text" id="searchInput" class="search-input" placeholder="搜索歌曲、歌手或专辑...">
-            <div class="source-select-wrapper" id="sourceSelectWrapper">
-                <button id="sourceSelectButton" class="source-select-btn" type="button" aria-haspopup="listbox" aria-expanded="false">
-                    <span id="sourceSelectLabel">网易云音乐</span>
-                    <i class="fas fa-chevron-down caret-icon" aria-hidden="true"></i>
+            <div class="mobile-toolbar__title" id="mobileToolbarTitle">Solara</div>
+            <div class="mobile-toolbar__actions">
+                <button class="mobile-toolbar__button" id="mobileSearchToggle" type="button" aria-label="打开搜索">
+                    <i class="fas fa-search" aria-hidden="true"></i>
                 </button>
-                <div id="sourceMenu" class="source-menu" role="listbox" aria-labelledby="sourceSelectButton"></div>
             </div>
-            <button id="searchBtn" class="search-btn">
-                <i class="fas fa-search"></i>
-                <span>搜索</span>
-            </button>
         </div>
-        <div id="searchResults" class="search-results"></div>
-    </div>
+        <div class="header">
+            <h1>Solara</h1>
+            <div class="warning">Made by Wet Dream Boy，免费API来自GD音乐台(music.gdstudio.xyz)，仅供学习交流使用，请支持正版音乐奥！</div>
+            <div class="theme-switch-wrapper">
+                <button id="themeToggleButton" class="theme-toggle-button" type="button" aria-label="切换深浅色模式">
+                    <i class="fas fa-sun theme-icon theme-icon--sun" aria-hidden="true"></i>
+                    <i class="fas fa-moon theme-icon theme-icon--moon" aria-hidden="true"></i>
+                </button>
+            </div>
+        </div>
 
-    <div class="main-content">
-        <div class="cover-area">
-            <div class="album-cover" id="albumCover">
-                <div class="placeholder">
-                    <i class="fas fa-music"></i>
+        <div class="search-area" id="searchArea">
+            <button type="button" class="mobile-close-btn" id="mobileSearchClose" aria-label="关闭搜索">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+            <div class="search-container">
+                <input type="text" id="searchInput" class="search-input" placeholder="搜索歌曲、歌手或专辑...">
+                <div class="source-select-wrapper" id="sourceSelectWrapper">
+                    <button id="sourceSelectButton" class="source-select-btn" type="button" aria-haspopup="listbox" aria-expanded="false">
+                        <span id="sourceSelectLabel">网易云音乐</span>
+                        <i class="fas fa-chevron-down caret-icon" aria-hidden="true"></i>
+                    </button>
+                    <div id="sourceMenu" class="source-menu" role="listbox" aria-labelledby="sourceSelectButton"></div>
+                </div>
+                <button id="searchBtn" class="search-btn">
+                    <i class="fas fa-search"></i>
+                    <span>搜索</span>
+                </button>
+            </div>
+            <div id="searchResults" class="search-results"></div>
+        </div>
+
+        <div class="main-content">
+            <div class="cover-area">
+                <div class="mobile-turntable" id="mobileTurntable">
+                    <div class="mobile-turntable__platter">
+                        <div class="album-cover" id="albumCover">
+                            <div class="placeholder">
+                                <i class="fas fa-music"></i>
+                            </div>
+                        </div>
+                        <div class="mobile-turntable__label" aria-hidden="true"></div>
+                    </div>
+                </div>
+                <div class="current-song-info">
+                    <div class="current-song-title" id="currentSongTitle">选择一首歌曲开始播放</div>
+                    <div class="current-song-artist" id="currentSongArtist">未知艺术家</div>
+                    <button class="mobile-quality-chip" id="mobileQualityToggle" type="button" aria-haspopup="menu" aria-expanded="false">
+                        <span id="mobileQualityLabel">极高音质</span>
+                        <i class="fas fa-chevron-down" aria-hidden="true"></i>
+                    </button>
                 </div>
             </div>
-            <div class="current-song-info">
-                <div class="current-song-title" id="currentSongTitle">选择一首歌曲开始播放</div>
-                <div class="current-song-artist" id="currentSongArtist">未知艺术家</div>
+
+            <div class="mobile-panel" id="mobilePanel">
+                <div class="mobile-panel-header" id="mobilePanelHeader">
+                    <div class="mobile-panel-handle" aria-hidden="true"></div>
+                    <div class="mobile-panel-title" id="mobilePanelTitle">播放列表</div>
+                    <button id="mobilePanelClose" class="mobile-close-btn" type="button" aria-label="收起播放面板">
+                        <i class="fas fa-chevron-down" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="view-toggle">
+                    <button id="showPlaylistBtn" class="active">播放列表</button>
+                    <button id="showLyricsBtn">歌词</button>
+                </div>
+
+                <div class="playlist active empty" id="playlist">
+                    <button class="clear-playlist-btn" id="clearPlaylistBtn" onclick="clearPlaylist()" title="清空播放列表">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                    <div class="playlist-scroll">
+                        <div class="playlist-items" id="playlistItems"></div>
+                    </div>
+                </div>
+                <div class="lyrics empty" id="lyrics" data-placeholder="default">
+                    <div class="lyrics-scroll" id="lyricsScroll">
+                        <div class="lyrics-content" id="lyricsContent"></div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="view-toggle">
-            <button id="showPlaylistBtn" class="active">播放列表</button>
-            <button id="showLyricsBtn">歌词</button>
-        </div>
-
-        <div class="playlist active empty" id="playlist">
-            <button class="clear-playlist-btn" id="clearPlaylistBtn" onclick="clearPlaylist()" title="清空播放列表">
-                <i class="fas fa-trash"></i>
-            </button>
-            <div class="playlist-scroll">
-                <div class="playlist-items" id="playlistItems"></div>
-            </div>
-        </div>
-        <div class="lyrics empty" id="lyrics" data-placeholder="default">
-            <div class="lyrics-scroll" id="lyricsScroll">
-                <div class="lyrics-content" id="lyricsContent"></div>
-            </div>
-        </div>
-    </div>
-
-    <div class="controls">
-        <div class="play-mode-controls">
-            <button class="play-mode-btn" id="playModeBtn" title="播放模式">
-                <i class="fas fa-repeat"></i>
-            </button>
-        </div>
-        <div class="transport-controls">
-            <button onclick="playPrevious()" title="上一曲"><i class="fas fa-backward-step"></i></button>
-            <button id="playPauseBtn" title="播放 / 暂停"><i class="fas fa-play"></i></button>
-            <button onclick="playNext()" title="下一曲"><i class="fas fa-forward-step"></i></button>
-        </div>
-        <div class="progress-container">
-            <span id="currentTimeDisplay">00:00</span>
-            <input type="range" id="progressBar" min="0" max="0" step="0.1" value="0">
-            <span id="durationDisplay">00:00</span>
-        </div>
-        <div class="audio-tools">
-            <div class="player-quality">
-                <button id="qualityToggle" class="player-quality-btn" type="button">
-                    <span id="qualityLabel">极高音质</span>
+        <div class="controls">
+            <div class="transport-controls">
+                <button class="play-mode-btn transport-button transport-button--mode" id="playModeBtn" type="button" title="播放模式">
+                    <i class="fas fa-repeat"></i>
                 </button>
-                <div id="playerQualityMenu" class="player-quality-menu"></div>
+                <button class="transport-button transport-button--prev" onclick="playPrevious()" type="button" title="上一曲"><i class="fas fa-backward-step"></i></button>
+                <button class="transport-button transport-button--play" id="playPauseBtn" type="button" title="播放 / 暂停"><i class="fas fa-play"></i></button>
+                <button class="transport-button transport-button--next" onclick="playNext()" type="button" title="下一曲"><i class="fas fa-forward-step"></i></button>
+                <button class="transport-button transport-button--queue" id="mobileQueueToggle" type="button" title="打开播放列表" aria-label="打开播放列表"><i class="fas fa-bars"></i></button>
             </div>
-            <div class="volume-container">
-                <i id="volumeIcon" class="fas fa-volume-up"></i>
-                <input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.8">
+            <div class="progress-container">
+                <span id="currentTimeDisplay">00:00</span>
+                <input type="range" id="progressBar" min="0" max="0" step="0.1" value="0">
+                <span id="durationDisplay">00:00</span>
             </div>
+            <div class="audio-tools">
+                <div class="player-quality">
+                    <button id="qualityToggle" class="player-quality-btn" type="button">
+                        <span id="qualityLabel">极高音质</span>
+                    </button>
+                    <div id="playerQualityMenu" class="player-quality-menu"></div>
+                </div>
+                <div class="volume-container">
+                    <i id="volumeIcon" class="fas fa-volume-up"></i>
+                    <input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.8">
+                </div>
+            </div>
+            <button id="loadOnlineBtn" title="聚合所有雷达，探索新音乐">
+                <span class="btn-text"><i class="fas fa-satellite-dish"></i> 探索雷达</span>
+                <span class="loader" style="display: none;"></span>
+            </button>
         </div>
-        <button id="loadOnlineBtn" title="聚合所有雷达，探索新音乐">
-            <span class="btn-text"><i class="fas fa-satellite-dish"></i> 探索雷达</span>
-            <span class="loader" style="display: none;"></span>
-        </button>
     </div>
-</div>
 
-<audio id="audioPlayer"></audio>
+    <div class="mobile-overlay-scrim" id="mobileOverlayScrim"></div>
+
+    <audio id="audioPlayer"></audio>
 
 <!-- 通知容器 -->
 <div id="notification" class="notification"></div>
@@ -124,5 +184,14 @@
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="js/index.js"></script>
+<script>
+    if (window.__SOLARA_IS_MOBILE) {
+        const mobileScript = document.createElement('script');
+        mobileScript.src = 'js/mobile.js';
+        mobileScript.async = false;
+        mobileScript.defer = false;
+        document.body.appendChild(mobileScript);
+    }
+</script>
 </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -34,7 +34,76 @@ const dom = {
     qualityToggle: document.getElementById("qualityToggle"),
     playerQualityMenu: document.getElementById("playerQualityMenu"),
     qualityLabel: document.getElementById("qualityLabel"),
+    mobileToolbarTitle: document.getElementById("mobileToolbarTitle"),
+    mobileSearchToggle: document.getElementById("mobileSearchToggle"),
+    mobileSearchClose: document.getElementById("mobileSearchClose"),
+    mobilePanelClose: document.getElementById("mobilePanelClose"),
+    mobileOverlayScrim: document.getElementById("mobileOverlayScrim"),
+    mobileBackButton: document.getElementById("mobileBackButton"),
+    mobileQualityToggle: document.getElementById("mobileQualityToggle"),
+    mobileQualityLabel: document.getElementById("mobileQualityLabel"),
+    mobilePanel: document.getElementById("mobilePanel"),
+    mobilePanelTitle: document.getElementById("mobilePanelTitle"),
+    mobileQueueToggle: document.getElementById("mobileQueueToggle"),
+    searchArea: document.getElementById("searchArea"),
 };
+
+window.SolaraDom = dom;
+
+const isMobileView = Boolean(window.__SOLARA_IS_MOBILE);
+
+const mobileBridge = window.SolaraMobileBridge || {};
+mobileBridge.handlers = mobileBridge.handlers || {};
+mobileBridge.queue = Array.isArray(mobileBridge.queue) ? mobileBridge.queue : [];
+window.SolaraMobileBridge = mobileBridge;
+
+function invokeMobileHook(name, ...args) {
+    if (!isMobileView) {
+        return undefined;
+    }
+    const handler = mobileBridge.handlers[name];
+    if (typeof handler === "function") {
+        return handler(...args);
+    }
+    mobileBridge.queue.push({ name, args });
+    return undefined;
+}
+
+function initializeMobileUI() {
+    return invokeMobileHook("initialize");
+}
+
+function updateMobileToolbarTitle() {
+    return invokeMobileHook("updateToolbarTitle");
+}
+
+function openMobileSearch() {
+    return invokeMobileHook("openSearch");
+}
+
+function closeMobileSearch() {
+    return invokeMobileHook("closeSearch");
+}
+
+function toggleMobileSearch() {
+    return invokeMobileHook("toggleSearch");
+}
+
+function openMobilePanel(view = "playlist") {
+    return invokeMobileHook("openPanel", view);
+}
+
+function closeMobilePanel() {
+    return invokeMobileHook("closePanel");
+}
+
+function toggleMobilePanel(view = "playlist") {
+    return invokeMobileHook("togglePanel", view);
+}
+
+function closeAllMobileOverlays() {
+    return invokeMobileHook("closeAllOverlays");
+}
 
 const PLACEHOLDER_HTML = `<div class="placeholder"><i class="fas fa-music"></i></div>`;
 const paletteCache = new Map();
@@ -372,6 +441,7 @@ const state = {
 let sourceMenuPositionFrame = null;
 let qualityMenuPositionFrame = null;
 let floatingMenuListenersAttached = false;
+let qualityMenuAnchor = null;
 
 function runWithoutTransition(element, callback) {
     if (!element || typeof callback !== "function") return;
@@ -940,6 +1010,9 @@ function updatePlayPauseButton() {
     const isPlaying = !dom.audioPlayer.paused && !dom.audioPlayer.ended;
     dom.playPauseBtn.innerHTML = `<i class="fas ${isPlaying ? "fa-pause" : "fa-play"}"></i>`;
     dom.playPauseBtn.title = isPlaying ? "暂停" : "播放";
+    if (document.body) {
+        document.body.classList.toggle("is-playing", isPlaying);
+    }
 }
 
 function updateProgressBarBackground(value = Number(dom.progressBar.value), max = Number(dom.progressBar.max)) {
@@ -1235,28 +1308,80 @@ function buildQualityMenu() {
     }
 }
 
+function isElementNode(value) {
+    return Boolean(value) && typeof value === "object" && value.nodeType === 1;
+}
+
+function resolveQualityAnchor(anchor) {
+    if (isElementNode(anchor)) {
+        return anchor;
+    }
+    if (isElementNode(dom.qualityToggle)) {
+        return dom.qualityToggle;
+    }
+    if (isElementNode(dom.mobileQualityToggle)) {
+        return dom.mobileQualityToggle;
+    }
+    return null;
+}
+
+function setQualityAnchorState(anchor, expanded) {
+    if (!isElementNode(anchor)) {
+        return;
+    }
+    anchor.classList.toggle("active", Boolean(expanded));
+    if (typeof anchor.setAttribute === "function") {
+        anchor.setAttribute("aria-expanded", expanded ? "true" : "false");
+    }
+}
+
+function getQualityMenuAnchor() {
+    if (isElementNode(qualityMenuAnchor) && (!document.body || document.body.contains(qualityMenuAnchor))) {
+        return qualityMenuAnchor;
+    }
+    const fallback = resolveQualityAnchor();
+    qualityMenuAnchor = fallback;
+    return fallback;
+}
+
 function updateQualityLabel() {
     const option = QUALITY_OPTIONS.find(item => item.value === state.playbackQuality) || QUALITY_OPTIONS[0];
     if (!option) return;
     dom.qualityLabel.textContent = option.label;
     dom.qualityToggle.title = `音质: ${option.label} (${option.description})`;
+    if (dom.mobileQualityLabel) {
+        dom.mobileQualityLabel.textContent = option.label;
+    }
+    if (dom.mobileQualityToggle) {
+        dom.mobileQualityToggle.title = `音质: ${option.label} (${option.description})`;
+    }
 }
 
 function togglePlayerQualityMenu(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    if (state.qualityMenuOpen) {
+    if (event) {
+        event.preventDefault();
+        event.stopPropagation();
+    }
+    const anchor = resolveQualityAnchor(event && event.currentTarget ? event.currentTarget : qualityMenuAnchor);
+    if (!anchor) {
+        return;
+    }
+    if (state.qualityMenuOpen && qualityMenuAnchor === anchor) {
         closePlayerQualityMenu();
     } else {
-        openPlayerQualityMenu();
+        openPlayerQualityMenu(anchor);
     }
 }
 
 function updatePlayerQualityMenuPosition() {
-    if (!state.qualityMenuOpen || !dom.playerQualityMenu || !dom.qualityToggle) return;
+    if (!state.qualityMenuOpen || !dom.playerQualityMenu) return;
 
+    const anchor = getQualityMenuAnchor();
+    if (!isElementNode(anchor)) {
+        return;
+    }
     const menu = dom.playerQualityMenu;
-    const toggleRect = dom.qualityToggle.getBoundingClientRect();
+    const toggleRect = anchor.getBoundingClientRect();
     const viewportWidth = Math.max(window.innerWidth || 0, document.documentElement.clientWidth || 0);
     const viewportHeight = Math.max(window.innerHeight || 0, document.documentElement.clientHeight || 0);
     const spacing = 10;
@@ -1307,12 +1432,20 @@ function resetPlayerQualityMenuPosition() {
     dom.playerQualityMenu.style.width = "";
 }
 
-function openPlayerQualityMenu() {
-    if (!dom.playerQualityMenu || !dom.qualityToggle) return;
+function openPlayerQualityMenu(anchor) {
+    if (!dom.playerQualityMenu) return;
+    const targetAnchor = resolveQualityAnchor(anchor);
+    if (!targetAnchor) {
+        return;
+    }
+    if (qualityMenuAnchor && qualityMenuAnchor !== targetAnchor) {
+        setQualityAnchorState(qualityMenuAnchor, false);
+    }
+    qualityMenuAnchor = targetAnchor;
     state.qualityMenuOpen = true;
     ensureFloatingMenuListeners();
     const menu = dom.playerQualityMenu;
-    dom.qualityToggle.classList.add("active");
+    setQualityAnchorState(qualityMenuAnchor, true);
     menu.classList.add("floating");
     menu.classList.remove("show");
 
@@ -1331,10 +1464,11 @@ function openPlayerQualityMenu() {
 function closePlayerQualityMenu() {
     if (!dom.playerQualityMenu) return;
     dom.playerQualityMenu.classList.remove("show");
-    dom.qualityToggle.classList.remove("active");
     state.qualityMenuOpen = false;
     cancelPlayerQualityMenuPositionUpdate();
     resetPlayerQualityMenuPosition();
+    setQualityAnchorState(qualityMenuAnchor, false);
+    qualityMenuAnchor = null;
     releaseFloatingMenuListenersIfIdle();
 }
 
@@ -1470,12 +1604,31 @@ function setupInteractions() {
         dom.sourceMenu.addEventListener("click", handleSourceSelection);
     }
     dom.qualityToggle.addEventListener("click", togglePlayerQualityMenu);
+    if (dom.mobileQualityToggle) {
+        dom.mobileQualityToggle.addEventListener("click", togglePlayerQualityMenu);
+    }
+    setQualityAnchorState(dom.qualityToggle, false);
+    if (dom.mobileQualityToggle) {
+        setQualityAnchorState(dom.mobileQualityToggle, false);
+    }
     dom.playerQualityMenu.addEventListener("click", handlePlayerQualitySelection);
 
     dom.loadOnlineBtn.addEventListener("click", exploreOnlineMusic);
 
-    dom.showPlaylistBtn.addEventListener("click", () => switchMobileView("playlist"));
-    dom.showLyricsBtn.addEventListener("click", () => switchMobileView("lyrics"));
+    dom.showPlaylistBtn.addEventListener("click", () => {
+        if (isMobileView) {
+            openMobilePanel("playlist");
+        } else {
+            switchMobileView("playlist");
+        }
+    });
+    dom.showLyricsBtn.addEventListener("click", () => {
+        if (isMobileView) {
+            openMobilePanel("lyrics");
+        } else {
+            switchMobileView("lyrics");
+        }
+    });
 
     // 播放模式按钮事件
     updatePlayModeUI();
@@ -1511,6 +1664,9 @@ function setupInteractions() {
         if (e.key === "Escape" && state.sourceMenuOpen) {
             closeSourceMenu();
         }
+        if (isMobileView && e.key === "Escape") {
+            closeAllMobileOverlays();
+        }
     });
 
     // 搜索结果相关事件处理 - 修复加载更多按钮点击问题
@@ -1526,8 +1682,12 @@ function setupInteractions() {
         });
 
         if (state.qualityMenuOpen &&
-            !dom.playerQualityMenu.contains(e.target) &&
-            !dom.qualityToggle.contains(e.target)) {
+            dom.playerQualityMenu &&
+            !dom.playerQualityMenu.contains(e.target)) {
+            const anchor = isElementNode(qualityMenuAnchor) ? qualityMenuAnchor : resolveQualityAnchor();
+            if (anchor && anchor.contains(e.target)) {
+                return;
+            }
             closePlayerQualityMenu();
         }
 
@@ -1615,6 +1775,10 @@ function setupInteractions() {
     if (state.currentSong) {
         restoreCurrentSongState();
     }
+
+    if (isMobileView) {
+        initializeMobileUI();
+    }
 }
 
 // 修复：更新当前歌曲信息和封面
@@ -1622,6 +1786,7 @@ function updateCurrentSongInfo(song, options = {}) {
     const { loadArtwork = true } = options;
     state.currentSong = song;
     dom.currentSongTitle.textContent = song.name;
+    updateMobileToolbarTitle();
 
     // 修复艺人名称显示问题 - 使用正确的字段名
     const artistText = Array.isArray(song.artist) ? song.artist.join(', ') : (song.artist || '未知艺术家');
@@ -2110,6 +2275,7 @@ function removeFromPlaylist(index) {
             dom.durationDisplay.textContent = "00:00";
             updateProgressBarBackground(0, 1);
             dom.currentSongTitle.textContent = "选择一首歌曲开始播放";
+            updateMobileToolbarTitle();
             dom.currentSongArtist.textContent = "未知艺术家";
             showAlbumCoverPlaceholder();
             if (dom.lyricsContent) {
@@ -2173,6 +2339,7 @@ function clearPlaylist() {
         dom.durationDisplay.textContent = "00:00";
         updateProgressBarBackground(0, 1);
         dom.currentSongTitle.textContent = "选择一首歌曲开始播放";
+        updateMobileToolbarTitle();
         dom.currentSongArtist.textContent = "未知艺术家";
         showAlbumCoverPlaceholder();
         if (dom.lyricsContent) {
@@ -2762,6 +2929,12 @@ function switchMobileView(view) {
         dom.showPlaylistBtn.classList.remove("active");
         dom.lyrics.classList.add("active");
         dom.playlist.classList.remove("active");
+    }
+    if (isMobileView && document.body) {
+        document.body.setAttribute("data-mobile-panel-view", view);
+        if (dom.mobilePanelTitle) {
+            dom.mobilePanelTitle.textContent = view === "lyrics" ? "歌词" : "播放列表";
+        }
     }
 }
 

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -1,0 +1,194 @@
+(function () {
+    if (!window.__SOLARA_IS_MOBILE) {
+        return;
+    }
+
+    const bridge = window.SolaraMobileBridge || {};
+    bridge.handlers = bridge.handlers || {};
+    bridge.queue = Array.isArray(bridge.queue) ? bridge.queue : [];
+    window.SolaraMobileBridge = bridge;
+
+    const dom = window.SolaraDom || {};
+    let initialized = false;
+
+    function updateMobileToolbarTitleImpl() {
+        if (!dom.mobileToolbarTitle || !dom.currentSongTitle) {
+            return;
+        }
+        const titleText = dom.currentSongTitle.textContent.trim();
+        dom.mobileToolbarTitle.textContent = titleText || "Solara";
+    }
+
+    function updateMobileOverlayScrim() {
+        if (!dom.mobileOverlayScrim || !document.body) {
+            return;
+        }
+        const hasOverlay = document.body.classList.contains("mobile-search-open") ||
+            document.body.classList.contains("mobile-panel-open");
+        dom.mobileOverlayScrim.setAttribute("aria-hidden", hasOverlay ? "false" : "true");
+    }
+
+    function openMobileSearchImpl() {
+        if (!document.body) {
+            return;
+        }
+        document.body.classList.add("mobile-search-open");
+        document.body.classList.remove("mobile-panel-open");
+        if (dom.searchArea) {
+            dom.searchArea.setAttribute("aria-hidden", "false");
+        }
+        updateMobileOverlayScrim();
+        if (dom.searchInput) {
+            window.requestAnimationFrame(() => {
+                try {
+                    dom.searchInput.focus({ preventScroll: true });
+                } catch (error) {
+                    dom.searchInput.focus();
+                }
+            });
+        }
+    }
+
+    function closeMobileSearchImpl() {
+        if (!document.body) {
+            return;
+        }
+        document.body.classList.remove("mobile-search-open");
+        if (dom.searchArea) {
+            dom.searchArea.setAttribute("aria-hidden", "true");
+        }
+        if (dom.searchInput) {
+            dom.searchInput.blur();
+        }
+        updateMobileOverlayScrim();
+    }
+
+    function toggleMobileSearchImpl() {
+        if (!document.body) {
+            return;
+        }
+        if (document.body.classList.contains("mobile-search-open")) {
+            closeMobileSearchImpl();
+        } else {
+            openMobileSearchImpl();
+        }
+    }
+
+    function normalizePanelView(view) {
+        return view === "lyrics" ? "playlist" : (view || "playlist");
+    }
+
+    function openMobilePanelImpl(view = "playlist") {
+        if (!document.body) {
+            return;
+        }
+        const targetView = normalizePanelView(view);
+        if (typeof window.switchMobileView === "function") {
+            window.switchMobileView(targetView);
+        }
+        document.body.classList.add("mobile-panel-open");
+        document.body.classList.remove("mobile-search-open");
+        if (dom.searchArea) {
+            dom.searchArea.setAttribute("aria-hidden", "true");
+        }
+        document.body.setAttribute("data-mobile-panel-view", targetView);
+        updateMobileOverlayScrim();
+    }
+
+    function closeMobilePanelImpl() {
+        if (!document.body) {
+            return;
+        }
+        document.body.classList.remove("mobile-panel-open");
+        updateMobileOverlayScrim();
+    }
+
+    function toggleMobilePanelImpl(view = "playlist") {
+        if (!document.body) {
+            return;
+        }
+        const isOpen = document.body.classList.contains("mobile-panel-open");
+        const currentView = document.body.getAttribute("data-mobile-panel-view") || "playlist";
+        const targetView = normalizePanelView(view);
+        if (isOpen && (!targetView || currentView === targetView)) {
+            closeMobilePanelImpl();
+        } else {
+            openMobilePanelImpl(targetView || currentView || "playlist");
+        }
+    }
+
+    function closeAllMobileOverlaysImpl() {
+        closeMobileSearchImpl();
+        closeMobilePanelImpl();
+    }
+
+    function initializeMobileUIImpl() {
+        if (initialized || !document.body) {
+            return;
+        }
+        initialized = true;
+
+        document.body.classList.add("mobile-view");
+        const initialView = "playlist";
+        document.body.setAttribute("data-mobile-panel-view", initialView);
+        if (dom.mobilePanelTitle) {
+            dom.mobilePanelTitle.textContent = "播放列表";
+        }
+        if (dom.lyrics) {
+            dom.lyrics.classList.remove("active");
+        }
+        if (dom.playlist) {
+            dom.playlist.classList.add("active");
+        }
+
+        updateMobileToolbarTitleImpl();
+
+        if (dom.mobileSearchToggle) {
+            dom.mobileSearchToggle.addEventListener("click", toggleMobileSearchImpl);
+        }
+        if (dom.mobileSearchClose) {
+            dom.mobileSearchClose.addEventListener("click", closeMobileSearchImpl);
+        }
+        if (dom.mobilePanelClose) {
+            dom.mobilePanelClose.addEventListener("click", closeMobilePanelImpl);
+        }
+        if (dom.mobileQueueToggle) {
+            dom.mobileQueueToggle.addEventListener("click", () => openMobilePanelImpl("playlist"));
+        }
+        if (dom.mobileOverlayScrim) {
+            dom.mobileOverlayScrim.addEventListener("click", closeAllMobileOverlaysImpl);
+        }
+        if (dom.mobileBackButton) {
+            dom.mobileBackButton.addEventListener("click", closeAllMobileOverlaysImpl);
+        }
+
+        if (dom.searchArea) {
+            dom.searchArea.setAttribute("aria-hidden", "true");
+        }
+        if (dom.mobileOverlayScrim) {
+            dom.mobileOverlayScrim.setAttribute("aria-hidden", "true");
+        }
+
+        updateMobileOverlayScrim();
+    }
+
+    bridge.handlers.updateToolbarTitle = updateMobileToolbarTitleImpl;
+    bridge.handlers.openSearch = openMobileSearchImpl;
+    bridge.handlers.closeSearch = closeMobileSearchImpl;
+    bridge.handlers.toggleSearch = toggleMobileSearchImpl;
+    bridge.handlers.openPanel = openMobilePanelImpl;
+    bridge.handlers.closePanel = closeMobilePanelImpl;
+    bridge.handlers.togglePanel = toggleMobilePanelImpl;
+    bridge.handlers.closeAllOverlays = closeAllMobileOverlaysImpl;
+    bridge.handlers.initialize = initializeMobileUIImpl;
+
+    if (bridge.queue.length) {
+        const pending = bridge.queue.splice(0, bridge.queue.length);
+        for (const entry of pending) {
+            const handler = bridge.handlers[entry.name];
+            if (typeof handler === "function") {
+                handler(...(entry.args || []));
+            }
+        }
+    }
+})();


### PR DESCRIPTION
## Summary
- rebuild the mobile record container so the album art spins inside a stable vinyl platter and drop the unused tonearm markup
- replace the mobile quality badge with a dropdown trigger, reuse the shared quality menu, and hide the old footer control
- keep the mobile playlist sheet focused on the playlist view while boosting its z-index and touch behaviour so items remain tappable

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e69dadf1e8832b861b65a189af7a76