### PR TITLE
Close playlist drawer after selection on mobile

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -6,7 +6,7 @@ body.mobile-view {
     color: #f2f5f9;
     height: 100%;
     overflow: hidden;
-    touch-action: manipulation;
+    touch-action: pan-y;
     overscroll-behavior: none;
 }
 
@@ -381,13 +381,12 @@ body.mobile-view .mobile-overlay-scrim {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.35s ease;
-    z-index: 30;
+    z-index: 40;
 }
 
 body.mobile-view.mobile-search-open .mobile-overlay-scrim,
 body.mobile-view.mobile-panel-open .mobile-overlay-scrim {
     opacity: 1;
-    pointer-events: auto;
 }
 
 body.mobile-view .mobile-panel {
@@ -403,13 +402,15 @@ body.mobile-view .mobile-panel {
     display: flex;
     flex-direction: column;
     gap: 18px;
-    z-index: 120;
+    z-index: 400;
     pointer-events: auto;
     box-shadow: 0 -28px 60px rgba(0, 0, 0, 0.6);
     transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+    height: calc(100dvh - clamp(120px, 34vw, 200px));
     max-height: calc(100dvh - clamp(120px, 34vw, 200px));
     overflow: hidden;
     overscroll-behavior: contain;
+    touch-action: pan-y;
 }
 
 body.mobile-view.mobile-panel-open .mobile-panel {
@@ -468,6 +469,7 @@ body.mobile-view .lyrics {
     padding: 0;
     max-height: none;
     flex: 1 1 auto;
+    min-height: 0;
 }
 
 body.mobile-view .playlist.active,
@@ -485,6 +487,7 @@ body.mobile-view .lyrics-scroll {
     flex: 1 1 auto;
     overscroll-behavior: contain;
     touch-action: pan-y;
+    min-height: 0;
 }
 
 body.mobile-view .playlist-items {
@@ -497,6 +500,11 @@ body.mobile-view .playlist-items .playlist-item {
     white-space: normal;
     line-height: 1.4;
     min-height: 52px;
+}
+
+body.mobile-view .playlist-items .playlist-item:focus-visible {
+    outline: 2px solid rgba(243, 162, 91, 0.85);
+    outline-offset: 2px;
 }
 
 body.mobile-view .playlist-items .playlist-item:hover {
@@ -565,14 +573,16 @@ body.mobile-view .search-area {
     backdrop-filter: blur(26px);
     transform: translateY(-100%);
     transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
-    z-index: 70;
+    z-index: 160;
     padding: calc(env(safe-area-inset-top) + 28px) clamp(18px, 6vw, 28px) clamp(env(safe-area-inset-bottom) + 24px, 8vw, 36px);
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     gap: 16px;
+    align-items: stretch;
+    justify-content: flex-start;
     opacity: 0;
     pointer-events: none;
-    align-items: center;
 }
 
 body.mobile-view.mobile-search-open .search-area {
@@ -587,10 +597,13 @@ body.mobile-view .search-area .mobile-close-btn {
 
 body.mobile-view .search-area .search-container,
 body.mobile-view .search-area .search-results {
-    width: min(100%, 360px);
-    max-width: 100%;
-    margin: 0 auto;
+    width: min(100%, 340px);
     box-sizing: border-box;
+}
+
+body.mobile-view .search-area > :not(.mobile-close-btn) {
+    width: min(100%, 340px);
+    align-self: center;
 }
 
 body.mobile-view .search-container {
@@ -638,7 +651,7 @@ body.mobile-view .search-results {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    width: min(100%, 360px);
+    width: min(100%, 340px);
     margin: 0 auto;
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -2293,6 +2293,9 @@ async function playSearchResult(index) {
         // 立即隐藏搜索结果，显示播放界面
         hideSearchResults();
         dom.searchInput.value = "";
+        if (isMobileView) {
+            closeMobileSearch();
+        }
 
         // 检查歌曲是否已在播放列表中
         const existingIndex = state.playlistSongs.findIndex(s => s.id === song.id && s.source === song.source);

--- a/js/index.js
+++ b/js/index.js
@@ -1549,6 +1549,90 @@ window.addEventListener("load", setupInteractions);
 dom.audioPlayer.addEventListener("ended", autoPlayNext);
 
 function setupInteractions() {
+    function ensureQualityMenuPortal() {
+        if (!dom.playerQualityMenu || !document.body || !isMobileView) {
+            return;
+        }
+        const currentParent = dom.playerQualityMenu.parentElement;
+        if (!currentParent || currentParent === document.body) {
+            return;
+        }
+        currentParent.removeChild(dom.playerQualityMenu);
+        document.body.appendChild(dom.playerQualityMenu);
+    }
+
+    function initializePlaylistEventHandlers() {
+        if (!dom.playlistItems) {
+            return;
+        }
+
+        const activatePlaylistItem = (index) => {
+            if (typeof index !== "number" || Number.isNaN(index)) {
+                return;
+            }
+            playPlaylistSong(index);
+        };
+
+        const handlePlaylistAction = (event, actionButton) => {
+            const index = Number(actionButton.dataset.index);
+            if (Number.isNaN(index)) {
+                return;
+            }
+
+            const action = actionButton.dataset.playlistAction;
+            if (action === "remove") {
+                event.preventDefault();
+                event.stopPropagation();
+                removeFromPlaylist(index);
+            } else if (action === "download") {
+                event.preventDefault();
+                event.stopPropagation();
+                showQualityMenu(event, index, "playlist");
+            }
+        };
+
+        const handleClick = (event) => {
+            const actionButton = event.target.closest("[data-playlist-action]");
+            if (actionButton) {
+                handlePlaylistAction(event, actionButton);
+                return;
+            }
+            const item = event.target.closest(".playlist-item");
+            if (!item || !dom.playlistItems.contains(item)) {
+                return;
+            }
+
+            const index = Number(item.dataset.index);
+            if (Number.isNaN(index)) {
+                return;
+            }
+
+            activatePlaylistItem(index);
+        };
+
+        const handleKeydown = (event) => {
+            if (event.key !== "Enter" && event.key !== " ") {
+                return;
+            }
+            if (event.target.closest("[data-playlist-action]")) {
+                return;
+            }
+            const item = event.target.closest(".playlist-item");
+            if (!item || !dom.playlistItems.contains(item)) {
+                return;
+            }
+            const index = Number(item.dataset.index);
+            if (Number.isNaN(index)) {
+                return;
+            }
+            event.preventDefault();
+            activatePlaylistItem(index);
+        };
+
+        dom.playlistItems.addEventListener("click", handleClick);
+        dom.playlistItems.addEventListener("keydown", handleKeydown);
+    }
+
     function applyTheme(isDark) {
         if (!state.themeDefaultsCaptured) {
             captureThemeDefaults();
@@ -1581,6 +1665,8 @@ function setupInteractions() {
     buildSourceMenu();
     updateSourceLabel();
     buildQualityMenu();
+    ensureQualityMenuPortal();
+    initializePlaylistEventHandlers();
     updateQualityLabel();
     updatePlayPauseButton();
     dom.currentTimeDisplay.textContent = formatTime(state.currentPlaybackTime);
@@ -2250,12 +2336,12 @@ function renderPlaylist() {
 
     dom.playlist.classList.remove("empty");
     const playlistHtml = state.playlistSongs.map((song, index) =>
-        `<div class="playlist-item" onclick="playPlaylistSong(${index})" data-index="${index}">
+        `<div class="playlist-item" data-index="${index}" role="button" tabindex="0" aria-label="播放 ${song.name}">
             ${song.name} - ${Array.isArray(song.artist) ? song.artist.join(", ") : song.artist}
-            <button class="playlist-item-remove" onclick="event.stopPropagation(); removeFromPlaylist(${index})" title="从播放列表移除">
+            <button class="playlist-item-remove" type="button" data-playlist-action="remove" data-index="${index}" title="从播放列表移除">
                 <i class="fas fa-times"></i>
             </button>
-            <button class="playlist-item-download" onclick="event.stopPropagation(); showQualityMenu(event, ${index}, 'playlist')" title="下载">
+            <button class="playlist-item-download" type="button" data-playlist-action="download" data-index="${index}" title="下载">
                 <i class="fas fa-download"></i>
             </button>
         </div>`
@@ -2386,6 +2472,9 @@ async function playPlaylistSong(index) {
     try {
         await playSong(song);
         updatePlaylistHighlight();
+        if (isMobileView) {
+            closeMobilePanel();
+        }
     } catch (error) {
         console.error("播放失败:", error);
         showNotification("播放失败，请稍后重试", "error");
@@ -2397,11 +2486,10 @@ function updatePlaylistHighlight() {
     if (!dom.playlistItems) return;
     const playlistItems = dom.playlistItems.querySelectorAll(".playlist-item");
     playlistItems.forEach((item, index) => {
-        if (state.currentPlaylist === "playlist" && index === state.currentTrackIndex) {
-            item.classList.add("current");
-        } else {
-            item.classList.remove("current");
-        }
+        const isCurrent = state.currentPlaylist === "playlist" && index === state.currentTrackIndex;
+        item.classList.toggle("current", isCurrent);
+        item.setAttribute("aria-current", isCurrent ? "true" : "false");
+        item.setAttribute("aria-pressed", isCurrent ? "true" : "false");
     });
 }
 

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -154,9 +154,34 @@
         if (dom.mobileQueueToggle) {
             dom.mobileQueueToggle.addEventListener("click", () => openMobilePanelImpl("playlist"));
         }
-        if (dom.mobileOverlayScrim) {
-            dom.mobileOverlayScrim.addEventListener("click", closeAllMobileOverlaysImpl);
-        }
+        const handleGlobalPointerDown = (event) => {
+            if (!document.body) {
+                return;
+            }
+            const hasOverlay = document.body.classList.contains("mobile-search-open") ||
+                document.body.classList.contains("mobile-panel-open");
+            if (!hasOverlay) {
+                return;
+            }
+
+            const target = event.target;
+            if (dom.mobilePanel && (dom.mobilePanel === target || dom.mobilePanel.contains(target))) {
+                return;
+            }
+            if (dom.searchArea && (dom.searchArea === target || dom.searchArea.contains(target))) {
+                return;
+            }
+            if (dom.playerQualityMenu && dom.playerQualityMenu.contains(target)) {
+                return;
+            }
+            if (target && typeof target.closest === "function" && target.closest(".quality-menu")) {
+                return;
+            }
+
+            closeAllMobileOverlaysImpl();
+        };
+
+        document.addEventListener("pointerdown", handleGlobalPointerDown, true);
         if (dom.searchArea) {
             dom.searchArea.setAttribute("aria-hidden", "true");
         }


### PR DESCRIPTION
## Summary
- keep the mobile playlist drawer above the scrim and route outside taps through a pointerdown handler so list items stay tappable and scrollable
- guard the new global pointerdown listener so downloads and other quality menus continue working when an overlay is open
- center the mobile search overlay by constraining its width and padding with border-box sizing to prevent the panel from drifting to the right
- automatically close the mobile playlist drawer after selecting a song so the playing view returns to focus on the main content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e76684c8e0832badc22b294320580e