### PR TITLE
Fix mobile layout scrolling and player clipping

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -4,7 +4,7 @@ html.mobile-view,
 body.mobile-view {
     background: radial-gradient(120% 140% at 50% 0%, #1b1d24 0%, #0d1018 70%, #05070c 100%);
     color: #f2f5f9;
-    height: 100%;
+    height: 100dvh;
     overflow: hidden;
     touch-action: pan-y;
     overscroll-behavior: none;
@@ -19,6 +19,7 @@ body.mobile-view {
     padding: calc(env(safe-area-inset-top) + 12px) clamp(12px, 5vw, 24px) calc(env(safe-area-inset-bottom) + 20px);
     font-family: var(--font-main);
     background-attachment: fixed;
+    box-sizing: border-box;
 }
 
 body.mobile-view .background-stage {


### PR DESCRIPTION
## Summary
- lock the mobile viewport to the device height to prevent scrolling gaps
- include body padding inside the viewport height so the player container renders fully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e78ac0a774832b9da73a5220f4875c