### PR TITLE
Improve iOS mobile viewport locking and playlist spacing

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -4,7 +4,8 @@ html.mobile-view,
 body.mobile-view {
     background: radial-gradient(120% 140% at 50% 0%, #1b1d24 0%, #0d1018 70%, #05070c 100%);
     color: #f2f5f9;
-    height: 100%;
+    height: var(--mobile-vh, 100dvh);
+    min-height: var(--mobile-vh, 100dvh);
     overflow: hidden;
     touch-action: pan-y;
     overscroll-behavior: none;
@@ -12,13 +13,17 @@ body.mobile-view {
 
 body.mobile-view {
     margin: 0;
-    min-height: 100dvh;
+    min-height: var(--mobile-vh, 100dvh);
     display: flex;
     justify-content: center;
     align-items: stretch;
     padding: calc(env(safe-area-inset-top) + 12px) clamp(12px, 5vw, 24px) calc(env(safe-area-inset-bottom) + 20px);
     font-family: var(--font-main);
     background-attachment: fixed;
+    box-sizing: border-box;
+    position: fixed;
+    inset: 0;
+    width: 100%;
 }
 
 body.mobile-view .background-stage {
@@ -40,7 +45,7 @@ body.mobile-view .container {
     position: relative;
     overflow: visible;
     flex: 1 1 auto;
-    min-height: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    min-height: calc(var(--mobile-vh, 100dvh) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     box-sizing: border-box;
 }
 
@@ -295,6 +300,18 @@ body.mobile-view .progress-container span {
     color: rgba(255, 255, 255, 0.6);
 }
 
+body.mobile-view .progress-container span:first-of-type {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+}
+
+body.mobile-view .progress-container span:last-of-type {
+    grid-column: 3;
+    grid-row: 2;
+    justify-self: end;
+}
+
 body.mobile-view .transport-controls {
     order: 2;
     width: 100%;
@@ -496,10 +513,11 @@ body.mobile-view .playlist-items {
 }
 
 body.mobile-view .playlist-items .playlist-item {
-    padding: 14px 60px 14px 18px;
+    padding: 12px 56px 12px 18px;
     white-space: normal;
-    line-height: 1.4;
-    min-height: 52px;
+    line-height: 1.35;
+    min-height: 0;
+    margin-bottom: 4px;
 }
 
 body.mobile-view .playlist-items .playlist-item:focus-visible {
@@ -529,11 +547,14 @@ body.mobile-view .playlist-items .playlist-item .playlist-item-remove {
 body.mobile-view .playlist-items .playlist-item {
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.05);
-    margin-bottom: 6px;
     color: #f2f4f7;
     touch-action: manipulation;
     cursor: pointer;
     pointer-events: auto;
+}
+
+body.mobile-view .playlist-items .playlist-item:last-child {
+    margin-bottom: 0;
 }
 
 body.mobile-view .playlist-items .playlist-item:hover,

--- a/index.html
+++ b/index.html
@@ -25,9 +25,15 @@
             link.href = "css/mobile.css";
             link.id = "mobileStylesheet";
             document.head.appendChild(link);
+            const setViewportUnit = () => {
+                const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+                document.documentElement.style.setProperty("--mobile-vh", `${viewportHeight}px`);
+            };
+
             const applyBodyClass = () => {
                 if (document.body) {
                     document.body.classList.add("mobile-view");
+                    setViewportUnit();
                 }
             };
             if (document.readyState === "loading") {
@@ -35,6 +41,15 @@
             } else {
                 applyBodyClass();
             }
+
+            window.addEventListener("resize", setViewportUnit);
+            window.addEventListener("orientationchange", setViewportUnit);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener("resize", setViewportUnit);
+                window.visualViewport.addEventListener("scroll", setViewportUnit);
+            }
+
+            setViewportUnit();
         })();
     </script>
 </head>


### PR DESCRIPTION
## Summary
- lock the mobile viewport to the device height to prevent scrolling gaps with dynamic updates on iOS Safari
- include body padding inside the viewport height so the player container renders fully
- align the progress bar timestamps and tighten playlist item spacing on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e78ac0a774832b9da73a5220f4875c