### PR TITLE
Improve iOS mobile viewport locking, playlist spacing, and controls

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -4,7 +4,8 @@ html.mobile-view,
 body.mobile-view {
     background: radial-gradient(120% 140% at 50% 0%, #1b1d24 0%, #0d1018 70%, #05070c 100%);
     color: #f2f5f9;
-    height: 100%;
+    height: var(--mobile-vh, 100dvh);
+    min-height: var(--mobile-vh, 100dvh);
     overflow: hidden;
     touch-action: pan-y;
     overscroll-behavior: none;
@@ -12,13 +13,17 @@ body.mobile-view {
 
 body.mobile-view {
     margin: 0;
-    min-height: 100dvh;
+    min-height: var(--mobile-vh, 100dvh);
     display: flex;
     justify-content: center;
     align-items: stretch;
     padding: calc(env(safe-area-inset-top) + 12px) clamp(12px, 5vw, 24px) calc(env(safe-area-inset-bottom) + 20px);
     font-family: var(--font-main);
     background-attachment: fixed;
+    box-sizing: border-box;
+    position: fixed;
+    inset: 0;
+    width: 100%;
 }
 
 body.mobile-view .background-stage {
@@ -40,7 +45,7 @@ body.mobile-view .container {
     position: relative;
     overflow: visible;
     flex: 1 1 auto;
-    min-height: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    min-height: calc(var(--mobile-vh, 100dvh) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     box-sizing: border-box;
 }
 
@@ -295,6 +300,18 @@ body.mobile-view .progress-container span {
     color: rgba(255, 255, 255, 0.6);
 }
 
+body.mobile-view .progress-container span:first-of-type {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+}
+
+body.mobile-view .progress-container span:last-of-type {
+    grid-column: 3;
+    grid-row: 2;
+    justify-self: end;
+}
+
 body.mobile-view .transport-controls {
     order: 2;
     width: 100%;
@@ -440,10 +457,14 @@ body.mobile-view .mobile-panel-title {
     letter-spacing: 0.04em;
 }
 
-body.mobile-view .mobile-panel-header .mobile-close-btn {
+body.mobile-view .mobile-panel-actions {
+    display: inline-flex;
+    align-items: center;
     justify-self: end;
+    gap: 10px;
 }
 
+body.mobile-view .mobile-panel-action-btn,
 body.mobile-view .mobile-close-btn {
     display: inline-flex;
     align-items: center;
@@ -454,10 +475,41 @@ body.mobile-view .mobile-close-btn {
     border: 1px solid rgba(255, 255, 255, 0.18);
     background: rgba(255, 255, 255, 0.08);
     color: #ffffff;
+    cursor: pointer;
+    transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
 }
 
+body.mobile-view .mobile-panel-action-btn i,
 body.mobile-view .mobile-close-btn i {
     pointer-events: none;
+}
+
+body.mobile-view .mobile-panel-action-btn:active,
+body.mobile-view .mobile-close-btn:active {
+    transform: translateY(1px);
+}
+
+body.mobile-view .mobile-panel-action-btn:focus-visible,
+body.mobile-view .mobile-close-btn:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.45);
+    outline-offset: 2px;
+}
+
+body.mobile-view .mobile-panel-clear-btn {
+    color: rgba(255, 255, 255, 0.9);
+    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+body.mobile-view .mobile-panel-clear-btn:not([hidden]):hover,
+body.mobile-view .mobile-panel-clear-btn:not([hidden]):focus-visible {
+    color: #ffd2b3;
+    border-color: rgba(255, 255, 255, 0.32);
+    background: rgba(255, 255, 255, 0.14);
+}
+
+body.mobile-view .mobile-panel-clear-btn[hidden] {
+    display: none !important;
 }
 
 body.mobile-view .playlist,
@@ -496,10 +548,11 @@ body.mobile-view .playlist-items {
 }
 
 body.mobile-view .playlist-items .playlist-item {
-    padding: 14px 60px 14px 18px;
+    padding: 12px 56px 12px 18px;
     white-space: normal;
-    line-height: 1.4;
-    min-height: 52px;
+    line-height: 1.35;
+    min-height: 0;
+    margin-bottom: 4px;
 }
 
 body.mobile-view .playlist-items .playlist-item:focus-visible {
@@ -529,11 +582,14 @@ body.mobile-view .playlist-items .playlist-item .playlist-item-remove {
 body.mobile-view .playlist-items .playlist-item {
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.05);
-    margin-bottom: 6px;
     color: #f2f4f7;
     touch-action: manipulation;
     cursor: pointer;
     pointer-events: auto;
+}
+
+body.mobile-view .playlist-items .playlist-item:last-child {
+    margin-bottom: 0;
 }
 
 body.mobile-view .playlist-items .playlist-item:hover,

--- a/index.html
+++ b/index.html
@@ -25,9 +25,15 @@
             link.href = "css/mobile.css";
             link.id = "mobileStylesheet";
             document.head.appendChild(link);
+            const setViewportUnit = () => {
+                const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+                document.documentElement.style.setProperty("--mobile-vh", `${viewportHeight}px`);
+            };
+
             const applyBodyClass = () => {
                 if (document.body) {
                     document.body.classList.add("mobile-view");
+                    setViewportUnit();
                 }
             };
             if (document.readyState === "loading") {
@@ -35,6 +41,15 @@
             } else {
                 applyBodyClass();
             }
+
+            window.addEventListener("resize", setViewportUnit);
+            window.addEventListener("orientationchange", setViewportUnit);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener("resize", setViewportUnit);
+                window.visualViewport.addEventListener("scroll", setViewportUnit);
+            }
+
+            setViewportUnit();
         })();
     </script>
 </head>
@@ -112,9 +127,22 @@
                 <div class="mobile-panel-header" id="mobilePanelHeader">
                     <div class="mobile-panel-handle" aria-hidden="true"></div>
                     <div class="mobile-panel-title" id="mobilePanelTitle">播放列表</div>
-                    <button id="mobilePanelClose" class="mobile-close-btn" type="button" aria-label="收起播放面板">
-                        <i class="fas fa-chevron-down" aria-hidden="true"></i>
-                    </button>
+                    <div class="mobile-panel-actions">
+                        <button
+                            id="mobileClearPlaylistBtn"
+                            class="mobile-panel-action-btn mobile-panel-clear-btn"
+                            type="button"
+                            aria-label="清空播放列表"
+                            title="清空播放列表"
+                            onclick="clearPlaylist()"
+                            hidden
+                        >
+                            <i class="fas fa-trash" aria-hidden="true"></i>
+                        </button>
+                        <button id="mobilePanelClose" class="mobile-close-btn mobile-panel-action-btn" type="button" aria-label="收起播放面板">
+                            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+                        </button>
+                    </div>
                 </div>
 
                 <div class="playlist active empty" id="playlist">

--- a/js/index.js
+++ b/js/index.js
@@ -38,6 +38,7 @@ const dom = {
     mobileSearchToggle: document.getElementById("mobileSearchToggle"),
     mobileSearchClose: document.getElementById("mobileSearchClose"),
     mobilePanelClose: document.getElementById("mobilePanelClose"),
+    mobileClearPlaylistBtn: document.getElementById("mobileClearPlaylistBtn"),
     mobileOverlayScrim: document.getElementById("mobileOverlayScrim"),
     mobileExploreButton: document.getElementById("mobileExploreButton"),
     mobileQualityToggle: document.getElementById("mobileQualityToggle"),
@@ -106,6 +107,25 @@ function syncMobileOverlayVisibility() {
     if (dom.mobileOverlayScrim) {
         dom.mobileOverlayScrim.setAttribute("aria-hidden", (searchOpen || panelOpen) ? "false" : "true");
     }
+}
+
+function updateMobileClearPlaylistVisibility() {
+    if (!isMobileView) {
+        return;
+    }
+    const button = dom.mobileClearPlaylistBtn;
+    if (!button) {
+        return;
+    }
+    const playlistElement = dom.playlist;
+    const body = document.body;
+    const currentView = body ? body.getAttribute("data-mobile-panel-view") : null;
+    const isPlaylistView = !body || !currentView || currentView === "playlist";
+    const playlistSongs = (typeof state !== "undefined" && Array.isArray(state.playlistSongs)) ? state.playlistSongs : [];
+    const isEmpty = playlistSongs.length === 0 || !playlistElement || playlistElement.classList.contains("empty");
+    const shouldShow = isPlaylistView && !isEmpty;
+    button.hidden = !shouldShow;
+    button.setAttribute("aria-hidden", shouldShow ? "false" : "true");
 }
 
 function forceCloseMobileSearchOverlay() {
@@ -1927,6 +1947,7 @@ function setupInteractions() {
         if (dom.playlistItems) {
             dom.playlistItems.innerHTML = "";
         }
+        updateMobileClearPlaylistVisibility();
     }
 
     if (state.currentSong) {
@@ -1935,6 +1956,7 @@ function setupInteractions() {
 
     if (isMobileView) {
         initializeMobileUI();
+        updateMobileClearPlaylistVisibility();
     }
 }
 
@@ -2393,6 +2415,7 @@ function renderPlaylist() {
         dom.playlistItems.innerHTML = "";
         savePlayerState();
         updatePlaylistHighlight();
+        updateMobileClearPlaylistVisibility();
         return;
     }
 
@@ -2412,6 +2435,7 @@ function renderPlaylist() {
     dom.playlistItems.innerHTML = playlistHtml;
     savePlayerState();
     updatePlaylistHighlight();
+    updateMobileClearPlaylistVisibility();
 }
 
 // 新增：从播放列表移除歌曲
@@ -2461,6 +2485,7 @@ function removeFromPlaylist(index) {
             dom.playlistItems.innerHTML = "";
         }
         state.currentPlaylist = "playlist";
+        updateMobileClearPlaylistVisibility();
     } else {
         if (state.currentPlaylist === "playlist" && state.currentTrackIndex < 0) {
             state.currentTrackIndex = 0;
@@ -2518,6 +2543,7 @@ function clearPlaylist() {
         dom.playlistItems.innerHTML = "";
     }
     state.currentPlaylist = "playlist";
+    updateMobileClearPlaylistVisibility();
 
     savePlayerState();
     showNotification("播放列表已清空", "success");
@@ -3105,6 +3131,7 @@ function switchMobileView(view) {
         if (dom.mobilePanelTitle) {
             dom.mobilePanelTitle.textContent = view === "lyrics" ? "歌词" : "播放列表";
         }
+        updateMobileClearPlaylistVisibility();
     }
 }
 


### PR DESCRIPTION
## Summary
- lock the mobile viewport to the device height to prevent scrolling gaps with dynamic updates on iOS Safari
- include body padding inside the viewport height so the player container renders fully
- align the progress bar timestamps and tighten playlist item spacing on mobile
- add a mobile clear playlist control next to the collapse button and keep it synced with playlist state and view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e78ac0a774832b9da73a5220f4875c