### PR TITLE
Add favicon metadata for Safari and browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Solara</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="shortcut icon" href="/favicon.svg">
+    <link rel="mask-icon" href="/favicon.svg" color="#5bbad5">
+    <link rel="apple-touch-icon" href="/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- register the root favicon.svg as the site icon, shortcut icon, and Apple touch icon
- add a Safari mask icon declaration for pinned tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e7bf01d3e0832b96843ee882bfe7fb