### PR TITLE
Update favicon references for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Solara</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <link rel="shortcut icon" href="/favicon.svg">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="shortcut icon" href="/favicon.png">
     <link rel="mask-icon" href="/favicon.svg" color="#5bbad5">
-    <link rel="apple-touch-icon" href="/favicon.svg">
+    <link rel="apple-touch-icon" href="/favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- point favicon references to the new PNG asset so Safari can display the icon when added to the home screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e7c3a39858832bbb64daddfc80edbc