### PR TITLE
Hide mobile inline lyrics overlay on desktop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1426,6 +1426,7 @@ input[type="range"]:active::-moz-range-thumb {
 }
 
 /* 新增：移动端结构在桌面端的默认表现 */
+/* Hide mobile specific chrome on desktop */
 .mobile-status-bar,
 .mobile-toolbar,
 .mobile-panel-header,
@@ -1434,6 +1435,11 @@ input[type="range"]:active::-moz-range-thumb {
 .mobile-close-btn,
 .mobile-turntable__tonearm,
 .mobile-turntable__label {
+    display: none;
+}
+
+/* Prevent the "tap to show lyrics" overlay from appearing on desktop */
+.mobile-inline-lyrics {
     display: none;
 }
 


### PR DESCRIPTION
## Summary
- hide the mobile inline lyrics panel in the desktop stylesheet so the cover remains static
- document why mobile-only UI pieces are suppressed on desktop

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68e7e1fbd62c832b905aa4501eda9eb4