### PR TITLE
Split desktop-only inline lyrics styles

### DIFF
--- a/css/desktop.css
+++ b/css/desktop.css
@@ -1,0 +1,12 @@
+/* Desktop-only overrides for mobile UI chrome */
+html.desktop-view .mobile-status-bar,
+html.desktop-view .mobile-toolbar,
+html.desktop-view .mobile-panel-header,
+html.desktop-view .mobile-overlay-scrim,
+html.desktop-view .mobile-quality-chip,
+html.desktop-view .mobile-close-btn,
+html.desktop-view .mobile-turntable__tonearm,
+html.desktop-view .mobile-turntable__label,
+html.desktop-view .mobile-inline-lyrics {
+    display: none;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1425,18 +1425,6 @@ input[type="range"]:active::-moz-range-thumb {
     display: none;
 }
 
-/* 新增：移动端结构在桌面端的默认表现 */
-.mobile-status-bar,
-.mobile-toolbar,
-.mobile-panel-header,
-.mobile-overlay-scrim,
-.mobile-quality-chip,
-.mobile-close-btn,
-.mobile-turntable__tonearm,
-.mobile-turntable__label {
-    display: none;
-}
-
 .mobile-panel {
     display: contents;
 }

--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
             const isMobile = isMobileUA || isSmallScreen;
             window.__SOLARA_IS_MOBILE = isMobile;
             if (!isMobile) {
+                document.documentElement.classList.add("desktop-view");
+                const desktopLink = document.createElement("link");
+                desktopLink.rel = "stylesheet";
+                desktopLink.href = "css/desktop.css";
+                desktopLink.id = "desktopStylesheet";
+                document.head.appendChild(desktopLink);
                 return;
             }
             document.documentElement.classList.add("mobile-view");


### PR DESCRIPTION
## Summary
- load a dedicated desktop stylesheet so mobile UI elements remain untouched on phones
- keep the main stylesheet neutral by moving the desktop-only overrides out of it

## Testing
- python - <<'PY'
import asyncio
from playwright.async_api import async_playwright

async def main():
    async with async_playwright() as p:
        browser = await p.chromium.launch()
        context = await browser.new_context()
        page = await context.new_page()
        await page.goto('http://127.0.0.1:8000/', wait_until='domcontentloaded')
        await page.wait_for_selector('#albumCover')
        display = await page.evaluate("getComputedStyle(document.querySelector('.mobile-inline-lyrics')).display")
        print('Desktop display:', display)
        await context.close()

        iphone = p.devices['iPhone 13']
        mobile_context = await browser.new_context(**iphone)
        mobile_page = await mobile_context.new_page()
        await mobile_page.goto('http://127.0.0.1:8000/', wait_until='domcontentloaded')
        await mobile_page.wait_for_selector('#albumCover')
        await mobile_page.evaluate("state.currentSong = { id: 'test' };")
        await mobile_page.evaluate("document.getElementById('mobileInlineLyricsContent').textContent = 'Test lyrics line';")
        await mobile_page.click('#albumCover')
        await mobile_page.wait_for_function("document.body.classList.contains('mobile-inline-lyrics-open')", timeout=3000)
        mobile_display = await mobile_page.evaluate("getComputedStyle(document.querySelector('.mobile-inline-lyrics')).display")
        print('Mobile display after tap:', mobile_display)
        aria_hidden = await mobile_page.get_attribute('#mobileInlineLyrics', 'aria-hidden')
        print('Mobile aria-hidden:', aria_hidden)
        await mobile_context.close()
        await browser.close()

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_b_68e7e1fbd62c832b905aa4501eda9eb4