### PR TITLE
Add dynamic gradient halo for portrait mobile layout

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -24,10 +24,54 @@ body.mobile-view {
     position: fixed;
     inset: 0;
     width: 100%;
+    --mobile-ring-inner-radius: clamp(280px, 70vw, 520px);
+    --mobile-ring-feather: clamp(120px, 24vw, 280px);
+    --mobile-ring-vertical-shift: calc((env(safe-area-inset-top, 0px) * 0.5) - 24px);
 }
 
 body.mobile-view .background-stage {
     display: none;
+}
+
+@media screen and (orientation: portrait) {
+    html.mobile-view,
+    body.mobile-view {
+        background: #06070d;
+    }
+
+    body.mobile-view {
+        --mobile-ring-inner-radius: clamp(260px, 64vw, 480px);
+        --mobile-ring-feather: clamp(110px, 22vw, 260px);
+        --mobile-ring-vertical-shift: calc((env(safe-area-inset-top, 0px) * 0.55) - 28px);
+    }
+
+    body.mobile-view .background-stage {
+        display: block;
+        z-index: -4;
+        -webkit-mask-image: radial-gradient(
+            circle at 50% calc(50% + var(--mobile-ring-vertical-shift)),
+            transparent calc(var(--mobile-ring-inner-radius)),
+            rgba(0, 0, 0, 0.92) calc(var(--mobile-ring-inner-radius) + var(--mobile-ring-feather)),
+            rgba(0, 0, 0, 1) 100%
+        );
+        mask-image: radial-gradient(
+            circle at 50% calc(50% + var(--mobile-ring-vertical-shift)),
+            transparent calc(var(--mobile-ring-inner-radius)),
+            rgba(0, 0, 0, 0.92) calc(var(--mobile-ring-inner-radius) + var(--mobile-ring-feather)),
+            rgba(0, 0, 0, 1) 100%
+        );
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: cover;
+        mask-size: cover;
+        -webkit-mask-position: center;
+        mask-position: center;
+    }
+
+    body.mobile-view .background-stage__layer {
+        transform: scale(1.12);
+        filter: saturate(112%);
+    }
 }
 
 body.mobile-view .container {


### PR DESCRIPTION
## Summary
- enable the shared background-stage gradient on portrait mobile screens and mask it into a halo that mirrors the desktop background logic
- introduce tunable CSS variables for the halo geometry so the mobile layout keeps the existing color accents when gradients change with album art

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e7e9eaebcc832b9495abaa35abaa5a