### PR TITLE
Fix mobile album cover distortion in responsive preview

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -181,6 +181,7 @@ body.mobile-view .mobile-turntable {
 
 body.mobile-view .mobile-turntable__platter {
     width: min(78vw, 320px);
+    height: min(78vw, 320px);
     aspect-ratio: 1 / 1;
     border-radius: 50%;
     background: radial-gradient(circle at 48% 50%, #1a1d25 0%, #05070c 65%, #000 100%);
@@ -212,6 +213,7 @@ body.mobile-view .album-cover {
     top: 50%;
     left: 50%;
     width: 58%;
+    height: 58%;
     aspect-ratio: 1 / 1;
     transform: translate(-50%, -50%);
     border-radius: 50%;
@@ -224,6 +226,7 @@ body.mobile-view .album-cover {
 }
 
 body.mobile-view .album-cover img {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;


### PR DESCRIPTION
## Summary
- ensure the mobile turntable platter enforces equal width and height so it stays circular in responsive simulations
- set explicit height on the album cover and make the image block-level to maintain the correct round appearance

## Testing
- Manual inspection in a simulated mobile viewport

------
https://chatgpt.com/codex/tasks/task_b_68e7efa3fe84832bbf8781594cde24a4