### PR TITLE
Center mobile quality menu under toggle

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1573,7 +1573,23 @@ function updatePlayerQualityMenuPosition() {
         }
     }
 
-    let left = Math.round(toggleRect.right - menuWidth);
+    const isPortraitOrientation = (() => {
+        if (typeof window.matchMedia === "function") {
+            const portraitQuery = window.matchMedia("(orientation: portrait)");
+            if (typeof portraitQuery.matches === "boolean") {
+                return portraitQuery.matches;
+            }
+        }
+        return viewportHeight >= viewportWidth;
+    })();
+
+    let left;
+    if (isMobileView && isPortraitOrientation) {
+        left = Math.round(toggleRect.left + (toggleRect.width - menuWidth) / 2);
+    } else {
+        left = Math.round(toggleRect.right - menuWidth);
+    }
+
     const minLeft = spacing;
     const maxLeft = Math.max(minLeft, viewportWidth - spacing - menuWidth);
     left = Math.min(Math.max(left, minLeft), maxLeft);


### PR DESCRIPTION
## Summary
- adjust floating quality menu positioning to detect portrait orientation
- center the menu horizontally over the mobile quality toggle when in portrait mobile view while keeping desktop behavior intact

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e7f3a7f310832b9146d70d908f7dd6