### PR TITLE
Fix mobile background palette fallback for dark mode

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -808,13 +808,39 @@ function applyDynamicGradient(options = {}) {
     applyThemeTokens(defaults);
 
     const palette = state.dynamicPalette;
-    if (palette && palette.gradients && palette.gradients[mode]) {
-        const gradientInfo = palette.gradients[mode];
+    if (palette && palette.gradients) {
+        const gradients = palette.gradients;
+        let gradientMode = mode;
+        let gradientInfo = gradients[gradientMode] || null;
+
+        if (!gradientInfo) {
+            const fallbackModes = gradientMode === "dark" ? ["light"] : ["dark"];
+            for (const candidate of fallbackModes) {
+                if (gradients[candidate]) {
+                    gradientMode = candidate;
+                    gradientInfo = gradients[candidate];
+                    break;
+                }
+            }
+            if (!gradientInfo) {
+                const availableModes = Object.keys(gradients);
+                if (availableModes.length) {
+                    const candidate = availableModes[0];
+                    gradientMode = candidate;
+                    gradientInfo = gradients[candidate];
+                }
+            }
+        }
+
         if (gradientInfo && gradientInfo.gradient) {
             targetGradient = gradientInfo.gradient;
         }
-        if (palette.tokens && palette.tokens[mode]) {
-            applyThemeTokens(palette.tokens[mode]);
+
+        if (palette.tokens) {
+            const tokens = palette.tokens[gradientMode] || palette.tokens[mode];
+            if (tokens) {
+                applyThemeTokens(tokens);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow the mobile background palette to fall back to any available gradient when the saved theme forces dark mode
- ensure dynamic token application matches the fallback gradient selection so cover-driven colors remain responsive

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68e861d11c5c832b8e164b3fb44ea36d