### PR TITLE
style: simplify desktop playlist label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -623,7 +623,7 @@ body.background-transitioning .background-stage__layer--transition {
     overflow: hidden;
 }
 
-.playlist {
+.playlist { 
     grid-area: playlist;
     background: var(--component-bg);
     border-radius: 16px;
@@ -636,6 +636,33 @@ body.background-transitioning .background-stage__layer--transition {
     position: relative;
     height: 100%;
     box-sizing: border-box;
+}
+
+.playlist-label {
+    position: absolute;
+    top: 16px;
+    left: 20px;
+    color: var(--text-secondary-color);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    line-height: 1.2;
+    display: none;
+    pointer-events: none;
+}
+
+html.desktop-view .playlist-label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+html.desktop-view body.dark-mode .playlist-label {
+    color: var(--text-color);
+}
+
+html.mobile-view .playlist-label {
+    display: none;
 }
 
 /* 当播放列表有内容时，调整布局 */

--- a/index.html
+++ b/index.html
@@ -168,6 +168,7 @@
                 </div>
 
                 <div class="playlist active empty" id="playlist">
+                    <div class="playlist-label" aria-hidden="true">播放列表</div>
                     <button class="clear-playlist-btn" id="clearPlaylistBtn" onclick="clearPlaylist()" title="清空播放列表">
                         <i class="fas fa-trash"></i>
                     </button>


### PR DESCRIPTION
## Summary
- remove the pill styling from the desktop playlist label so it renders as plain text
- keep the label positioned for desktop without affecting the mobile layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e8635ecb10832b8dafc0caf4d2aa5a