### PR TITLE
Cleanup API object to prevent legacy method reuse

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -464,7 +464,6 @@ const savedCurrentPlaylist = (() => {
 
 // API配置 - 修复API地址和请求方式
 const API = {
-    name: "GD Studio API",
     baseUrl: "/proxy",
 
     generateSignature: () => {
@@ -591,6 +590,8 @@ const API = {
         return `${API.baseUrl}?types=pic&id=${song.pic_id}&source=${song.source || "netease"}&size=300&s=${signature}`;
     }
 };
+
+Object.freeze(API);
 
 const state = {
     onlineSongs: [],


### PR DESCRIPTION
## Summary
- remove the unused API name metadata that belonged to the legacy getList helper
- freeze the API object to discourage reintroducing removed legacy properties

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68e947687134832ba7fed87969699f6c