### PR TITLE
Add mobile playlist import/export controls

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -636,6 +636,12 @@ body.mobile-view .mobile-close-btn:focus-visible {
     outline-offset: 2px;
 }
 
+body.mobile-view .mobile-panel-action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 body.mobile-view .mobile-panel-clear-btn {
     color: rgba(255, 255, 255, 0.9);
     border-color: rgba(255, 255, 255, 0.2);

--- a/css/style.css
+++ b/css/style.css
@@ -623,11 +623,11 @@ body.background-transitioning .background-stage__layer--transition {
     overflow: hidden;
 }
 
-.playlist { 
+.playlist {
     grid-area: playlist;
     background: var(--component-bg);
     border-radius: 16px;
-    padding: 20px;
+    padding: 72px 20px 24px;
     border: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
@@ -638,23 +638,32 @@ body.background-transitioning .background-stage__layer--transition {
     box-sizing: border-box;
 }
 
-.playlist-label {
+
+.playlist-header {
     position: absolute;
     top: 16px;
     left: 20px;
+    right: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.playlist-label {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
     color: var(--text-secondary-color);
     font-size: 15px;
     font-weight: 600;
     letter-spacing: 0.08em;
     line-height: 1.2;
-    display: none;
     pointer-events: none;
-}
-
-html.desktop-view .playlist-label {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    text-transform: none;
+    white-space: nowrap;
 }
 
 html.desktop-view body.dark-mode .playlist-label {
@@ -665,11 +674,98 @@ html.mobile-view .playlist-label {
     display: none;
 }
 
+.playlist-actions-tray {
+    pointer-events: auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(255, 255, 255, 0.78);
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    transition: box-shadow 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+
+body.dark-mode .playlist-actions-tray {
+    background: rgba(20, 24, 33, 0.78);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.playlist-action-btn {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary-color);
+    font-size: 15px;
+    cursor: pointer;
+    transition: color 0.25s ease, background 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+    box-shadow: inset 0 0 0 1px transparent;
+}
+
+.playlist-action-btn i {
+    pointer-events: none;
+}
+
+.playlist-action-btn:hover:not(:disabled),
+.playlist-action-btn:focus-visible:not(:disabled) {
+    color: var(--primary-color);
+    background: rgba(26, 188, 156, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(26, 188, 156, 0.35), 0 6px 16px rgba(26, 188, 156, 0.25);
+    transform: translateY(-1px);
+}
+
+.playlist-action-btn:focus-visible {
+    outline: none;
+}
+
+.playlist-action-btn--export:hover:not(:disabled),
+.playlist-action-btn--export:focus-visible:not(:disabled) {
+    color: var(--primary-color-dark);
+}
+
+.playlist-action-btn--clear {
+    color: rgba(231, 76, 60, 0.85);
+}
+
+.playlist-action-btn--clear:hover:not(:disabled),
+.playlist-action-btn--clear:focus-visible:not(:disabled) {
+    background: rgba(231, 76, 60, 0.16);
+    box-shadow: inset 0 0 0 1px rgba(231, 76, 60, 0.35), 0 8px 18px rgba(231, 76, 60, 0.28);
+    color: var(--warning-color);
+}
+
+.playlist-action-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.playlist-action-btn:disabled:hover {
+    background: transparent;
+}
+
+.playlist-import-input {
+    display: none;
+}
+
+html.mobile-view .playlist-header {
+    display: none;
+}
+
 /* 当播放列表有内容时，调整布局 */
 .playlist:not(.empty) {
     align-items: stretch;
     justify-content: flex-start;
-    padding-top: 56px; /* Provide space for the clear button */
 }
 
 /* 播放列表空状态的提示文本 */
@@ -679,41 +775,6 @@ html.mobile-view .playlist-label {
     font-style: italic;
     opacity: 0.7;
     font-size: 0.9em;
-}
-
-/* 清空播放列表按钮 */
-.clear-playlist-btn {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    border: 1px solid var(--border-color);
-    background: var(--component-bg);
-    color: var(--text-secondary-color);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
-    cursor: pointer;
-    transition: all 0.25s ease;
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    z-index: 1000;
-    font-size: 16px;
-}
-
-.clear-playlist-btn:hover {
-    color: var(--warning-color);
-    border-color: rgba(231, 76, 60, 0.45);
-    box-shadow: 0 10px 25px rgba(231, 76, 60, 0.25);
-    transform: translateY(-2px);
-}
-
-.clear-playlist-btn:active {
-    transform: translateY(0);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
 
 .playlist-scroll {
@@ -731,10 +792,6 @@ html.mobile-view .playlist-label {
 
 .playlist-items {
     width: 100%;
-}
-
-.playlist.empty .clear-playlist-btn {
-    display: none;
 }
 
 .playlist-items .playlist-item {

--- a/index.html
+++ b/index.html
@@ -151,6 +151,26 @@
                     <div class="mobile-panel-title" id="mobilePanelTitle">播放列表</div>
                     <div class="mobile-panel-actions">
                         <button
+                            id="mobileImportPlaylistBtn"
+                            class="mobile-panel-action-btn"
+                            type="button"
+                            aria-label="导入播放列表"
+                            title="导入播放列表"
+                        >
+                            <i class="fas fa-file-import" aria-hidden="true"></i>
+                        </button>
+                        <button
+                            id="mobileExportPlaylistBtn"
+                            class="mobile-panel-action-btn"
+                            type="button"
+                            aria-label="导出播放列表"
+                            title="导出播放列表"
+                            aria-disabled="true"
+                            disabled
+                        >
+                            <i class="fas fa-file-export" aria-hidden="true"></i>
+                        </button>
+                        <button
                             id="mobileClearPlaylistBtn"
                             class="mobile-panel-action-btn mobile-panel-clear-btn"
                             type="button"
@@ -158,6 +178,7 @@
                             title="清空播放列表"
                             onclick="clearPlaylist()"
                             hidden
+                            aria-hidden="true"
                         >
                             <i class="fas fa-trash" aria-hidden="true"></i>
                         </button>
@@ -168,10 +189,46 @@
                 </div>
 
                 <div class="playlist active empty" id="playlist">
-                    <div class="playlist-label" aria-hidden="true">播放列表</div>
-                    <button class="clear-playlist-btn" id="clearPlaylistBtn" onclick="clearPlaylist()" title="清空播放列表">
-                        <i class="fas fa-trash"></i>
-                    </button>
+                    <div class="playlist-header">
+                        <div class="playlist-label" aria-hidden="true">播放列表</div>
+                        <div class="playlist-actions-tray" role="group" aria-label="播放列表操作">
+                            <input
+                                id="importPlaylistInput"
+                                class="playlist-import-input"
+                                type="file"
+                                accept="application/json"
+                                hidden
+                            />
+                            <button
+                                class="playlist-action-btn playlist-action-btn--import"
+                                id="importPlaylistBtn"
+                                type="button"
+                                title="导入播放列表"
+                                aria-label="导入播放列表"
+                            >
+                                <i class="fas fa-file-import" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                class="playlist-action-btn playlist-action-btn--export"
+                                id="exportPlaylistBtn"
+                                type="button"
+                                title="导出播放列表"
+                                aria-label="导出播放列表"
+                            >
+                                <i class="fas fa-file-export" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                class="playlist-action-btn playlist-action-btn--clear clear-playlist-btn"
+                                id="clearPlaylistBtn"
+                                type="button"
+                                onclick="clearPlaylist()"
+                                title="清空播放列表"
+                                aria-label="清空播放列表"
+                            >
+                                <i class="fas fa-trash" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
                     <div class="playlist-scroll">
                         <div class="playlist-items" id="playlistItems"></div>
                     </div>

--- a/js/index.js
+++ b/js/index.js
@@ -27,6 +27,12 @@ const dom = {
     currentSongTitle: document.getElementById("currentSongTitle"),
     currentSongArtist: document.getElementById("currentSongArtist"),
     debugInfo: document.getElementById("debugInfo"),
+    importPlaylistBtn: document.getElementById("importPlaylistBtn"),
+    exportPlaylistBtn: document.getElementById("exportPlaylistBtn"),
+    importPlaylistInput: document.getElementById("importPlaylistInput"),
+    clearPlaylistBtn: document.getElementById("clearPlaylistBtn"),
+    mobileImportPlaylistBtn: document.getElementById("mobileImportPlaylistBtn"),
+    mobileExportPlaylistBtn: document.getElementById("mobileExportPlaylistBtn"),
     playModeBtn: document.getElementById("playModeBtn"),
     playPauseBtn: document.getElementById("playPauseBtn"),
     progressBar: document.getElementById("progressBar"),
@@ -429,6 +435,8 @@ const savedPlaylistSongs = (() => {
     const playlist = parseJSON(stored, []);
     return Array.isArray(playlist) ? playlist : [];
 })();
+
+const PLAYLIST_EXPORT_VERSION = 1;
 
 const savedCurrentTrackIndex = (() => {
     const stored = safeGetLocalStorage("currentTrackIndex");
@@ -2292,6 +2300,29 @@ function setupInteractions() {
         });
     }
 
+    if (dom.importPlaylistBtn && dom.importPlaylistInput) {
+        dom.importPlaylistBtn.addEventListener("click", () => {
+            dom.importPlaylistInput.value = "";
+            dom.importPlaylistInput.click();
+        });
+        dom.importPlaylistInput.addEventListener("change", handleImportPlaylistChange);
+    }
+
+    if (dom.exportPlaylistBtn) {
+        dom.exportPlaylistBtn.addEventListener("click", exportPlaylist);
+    }
+
+    if (dom.mobileImportPlaylistBtn && dom.importPlaylistInput) {
+        dom.mobileImportPlaylistBtn.addEventListener("click", () => {
+            dom.importPlaylistInput.value = "";
+            dom.importPlaylistInput.click();
+        });
+    }
+
+    if (dom.mobileExportPlaylistBtn) {
+        dom.mobileExportPlaylistBtn.addEventListener("click", exportPlaylist);
+    }
+
     if (dom.showPlaylistBtn) {
         dom.showPlaylistBtn.addEventListener("click", () => {
             if (isMobileView) {
@@ -2431,6 +2462,8 @@ function setupInteractions() {
 
     attachLyricScrollHandler(dom.lyricsScroll, () => dom.lyricsContent?.querySelector(".current"));
     attachLyricScrollHandler(dom.mobileInlineLyricsScroll, () => dom.mobileInlineLyricsContent?.querySelector(".current"));
+
+    updatePlaylistActionStates();
 
     if (state.playlistSongs.length > 0) {
         let restoredIndex = state.currentTrackIndex;
@@ -2924,6 +2957,302 @@ async function playSearchResult(index) {
     }
 }
 
+function resolveSongId(song) {
+    if (!song || typeof song !== "object") {
+        return null;
+    }
+    const candidates = [
+        "id",
+        "songId",
+        "songid",
+        "songmid",
+        "mid",
+        "hash",
+        "sid",
+        "rid",
+        "trackId"
+    ];
+    for (const key of candidates) {
+        if (Object.prototype.hasOwnProperty.call(song, key)) {
+            const value = song[key];
+            if (typeof value === "number" && Number.isFinite(value)) {
+                return String(value);
+            }
+            if (typeof value === "string" && value.trim() !== "") {
+                return value.trim();
+            }
+        }
+    }
+    return null;
+}
+
+function normalizeArtistValue(value) {
+    if (Array.isArray(value)) {
+        const names = value.map((item) => {
+            if (typeof item === "string") {
+                return item.trim();
+            }
+            if (item && typeof item === "object" && typeof item.name === "string") {
+                return item.name.trim();
+            }
+            return "";
+        }).filter(Boolean);
+        if (names.length === 0) {
+            return undefined;
+        }
+        if (names.length === 1) {
+            return names[0];
+        }
+        return names;
+    }
+    if (value && typeof value === "object" && typeof value.name === "string") {
+        const name = value.name.trim();
+        return name || undefined;
+    }
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed || undefined;
+    }
+    return undefined;
+}
+
+function getSongKey(song) {
+    if (!song || typeof song !== "object") {
+        return null;
+    }
+    const source = typeof song.source === "string" && song.source.trim() !== ""
+        ? song.source.trim().toLowerCase()
+        : (typeof song.platform === "string" && song.platform.trim() !== ""
+            ? song.platform.trim().toLowerCase()
+            : "netease");
+    const id = resolveSongId(song);
+    if (id) {
+        return `${source}:${id}`;
+    }
+    const name = typeof song.name === "string" ? song.name.trim().toLowerCase() : "";
+    if (!name) {
+        return null;
+    }
+    const artistValue = song.artist ?? song.artists ?? song.singers ?? song.singer;
+    let artistText = "";
+    if (Array.isArray(artistValue)) {
+        artistText = artistValue.map((item) => {
+            if (typeof item === "string") {
+                return item.trim().toLowerCase();
+            }
+            if (item && typeof item === "object" && typeof item.name === "string") {
+                return item.name.trim().toLowerCase();
+            }
+            return "";
+        }).filter(Boolean).join(",");
+    } else if (artistValue && typeof artistValue === "object" && typeof artistValue.name === "string") {
+        artistText = artistValue.name.trim().toLowerCase();
+    } else if (typeof artistValue === "string") {
+        artistText = artistValue.trim().toLowerCase();
+    }
+    return `${source}:${name}::${artistText}`;
+}
+
+function sanitizeImportedSong(rawSong) {
+    if (!rawSong || typeof rawSong !== "object") {
+        return null;
+    }
+    const name = typeof rawSong.name === "string" ? rawSong.name.trim() : "";
+    if (!name) {
+        return null;
+    }
+
+    const normalized = { ...rawSong, name };
+    const sourceCandidate = rawSong.source || rawSong.platform || rawSong.provider || rawSong.vendor;
+    normalized.source = typeof sourceCandidate === "string" && sourceCandidate.trim() !== ""
+        ? sourceCandidate.trim()
+        : "netease";
+
+    const resolvedId = resolveSongId(rawSong);
+    if (resolvedId) {
+        normalized.id = resolvedId;
+    }
+
+    const artistValue = rawSong.artist ?? rawSong.artists ?? rawSong.singers ?? rawSong.singer;
+    const normalizedArtist = normalizeArtistValue(artistValue);
+    if (normalizedArtist !== undefined) {
+        normalized.artist = normalizedArtist;
+    }
+
+    if (normalized.album && typeof normalized.album === "object" && typeof normalized.album.name === "string") {
+        normalized.album = normalized.album.name.trim();
+    }
+
+    return normalized;
+}
+
+function extractPlaylistItems(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+    if (payload && typeof payload === "object") {
+        const possibleKeys = ["items", "songs", "playlist", "tracks", "data"];
+        for (const key of possibleKeys) {
+            if (Array.isArray(payload[key])) {
+                return payload[key];
+            }
+        }
+    }
+    return [];
+}
+
+function updatePlaylistActionStates() {
+    const hasSongs = Array.isArray(state.playlistSongs) && state.playlistSongs.length > 0;
+    if (dom.exportPlaylistBtn) {
+        dom.exportPlaylistBtn.disabled = !hasSongs;
+        dom.exportPlaylistBtn.setAttribute("aria-disabled", hasSongs ? "false" : "true");
+    }
+    if (dom.mobileExportPlaylistBtn) {
+        dom.mobileExportPlaylistBtn.disabled = !hasSongs;
+        dom.mobileExportPlaylistBtn.setAttribute("aria-disabled", hasSongs ? "false" : "true");
+    }
+    if (dom.clearPlaylistBtn) {
+        dom.clearPlaylistBtn.disabled = !hasSongs;
+        dom.clearPlaylistBtn.setAttribute("aria-disabled", hasSongs ? "false" : "true");
+    }
+    if (dom.mobileClearPlaylistBtn) {
+        dom.mobileClearPlaylistBtn.disabled = !hasSongs;
+        dom.mobileClearPlaylistBtn.setAttribute("aria-disabled", hasSongs ? "false" : "true");
+    }
+}
+
+function exportPlaylist() {
+    if (!Array.isArray(state.playlistSongs) || state.playlistSongs.length === 0) {
+        showNotification("播放列表为空，无法导出", "warning");
+        return;
+    }
+
+    try {
+        const payload = {
+            meta: {
+                app: "Solara",
+                version: PLAYLIST_EXPORT_VERSION,
+                exportedAt: new Date().toISOString(),
+                itemCount: state.playlistSongs.length
+            },
+            items: state.playlistSongs
+        };
+
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const now = new Date();
+        const formattedTimestamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`;
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = `solara-playlist-${formattedTimestamp}.json`;
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        URL.revokeObjectURL(url);
+        showNotification(`已导出 ${state.playlistSongs.length} 首歌曲`, "success");
+    } catch (error) {
+        console.error("导出播放列表失败:", error);
+        showNotification("导出失败，请稍后重试", "error");
+    }
+}
+
+function handleImportedPlaylistItems(rawItems) {
+    if (!Array.isArray(state.playlistSongs)) {
+        state.playlistSongs = [];
+    }
+
+    const sanitizedSongs = rawItems
+        .map(sanitizeImportedSong)
+        .filter((song) => song && typeof song === "object");
+
+    if (sanitizedSongs.length === 0) {
+        throw new Error("NO_VALID_SONGS");
+    }
+
+    const existingKeys = new Set(
+        state.playlistSongs
+            .map(getSongKey)
+            .filter((key) => typeof key === "string" && key !== "")
+    );
+
+    let added = 0;
+    let duplicates = 0;
+
+    sanitizedSongs.forEach((song) => {
+        const key = getSongKey(song);
+        if (key && existingKeys.has(key)) {
+            duplicates++;
+            return;
+        }
+        state.playlistSongs.push(song);
+        if (key) {
+            existingKeys.add(key);
+        }
+        added++;
+    });
+
+    if (added > 0) {
+        renderPlaylist();
+    } else {
+        updatePlaylistActionStates();
+    }
+
+    return { added, duplicates };
+}
+
+function handleImportPlaylistChange(event) {
+    const input = event?.target;
+    const file = input?.files?.[0];
+    if (!file) {
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+        try {
+            const text = typeof reader.result === "string" ? reader.result : "";
+            if (!text) {
+                throw new Error("EMPTY_FILE");
+            }
+
+            const payload = parseJSON(text, null);
+            if (!payload) {
+                throw new Error("INVALID_JSON");
+            }
+
+            const items = extractPlaylistItems(payload);
+            if (!Array.isArray(items) || items.length === 0) {
+                throw new Error("NO_SONGS");
+            }
+
+            const { added, duplicates } = handleImportedPlaylistItems(items);
+            if (added > 0) {
+                const duplicateHint = duplicates > 0 ? `，${duplicates} 首已存在` : "";
+                showNotification(`成功导入 ${added} 首歌曲${duplicateHint}`, "success");
+            } else {
+                showNotification("文件中的歌曲已在播放列表中", "warning");
+            }
+        } catch (error) {
+            console.error("导入播放列表失败:", error);
+            showNotification("导入失败，请确认文件格式", "error");
+        } finally {
+            if (input) {
+                input.value = "";
+            }
+        }
+    };
+
+    reader.onerror = () => {
+        console.error("读取播放列表文件失败:", reader.error);
+        showNotification("无法读取播放列表文件", "error");
+        if (input) {
+            input.value = "";
+        }
+    };
+
+    reader.readAsText(file, "utf-8");
+}
+
 // 新增：渲染统一播放列表
 function renderPlaylist() {
     if (!dom.playlistItems) return;
@@ -2934,6 +3263,7 @@ function renderPlaylist() {
         savePlayerState();
         updatePlaylistHighlight();
         updateMobileClearPlaylistVisibility();
+        updatePlaylistActionStates();
         return;
     }
 
@@ -2954,6 +3284,7 @@ function renderPlaylist() {
     savePlayerState();
     updatePlaylistHighlight();
     updateMobileClearPlaylistVisibility();
+    updatePlaylistActionStates();
 }
 
 // 新增：从播放列表移除歌曲
@@ -3018,6 +3349,7 @@ function removeFromPlaylist(index) {
         }
     }
 
+    updatePlaylistActionStates();
     savePlayerState();
     showNotification("已从播放列表移除", "success");
 }
@@ -3058,6 +3390,7 @@ function clearPlaylist() {
     }
     state.currentPlaylist = "playlist";
     updateMobileClearPlaylistVisibility();
+    updatePlaylistActionStates();
 
     savePlayerState();
     showNotification("播放列表已清空", "success");


### PR DESCRIPTION
## Summary
- add a dedicated action tray beside the playlist title with import, export, and clear controls
- style the playlist header tray for desktop while keeping the mobile layout unaffected
- implement JSON-based playlist import/export handling and update action button states dynamically
- add matching import, export, and clear controls to the mobile playlist drawer header

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f3c6ca5d68832b96fa063957d96606