### PR TITLE
Add optional password protection for Solara Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ## ⚙️ 配置提示
 - 🔗 API 基地址定义在 index.html 中的 `API.baseUrl`（约 1300 行），可替换为自建接口域名。
 - 🎚️ 默认主题、播放模式等偏好可在 `state` 初始化逻辑中按需调整。
+- 🔐 如需启用访问密码，可在 Cloudflare Pages 项目的 **Environment Variables** 中新增 `ACCESS_PASSWORD` 并重新部署。站点会在进入前显示 Solara 风格的密码页；删除该变量后站点将恢复公开访问。
 
 ## 🎵 使用流程
 1. 输入关键词并选择想要的曲库后发起搜索。

--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,187 @@
     color: #ffffff;
 }
 
+.auth-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(10, 18, 16, 0.78);
+    backdrop-filter: blur(18px);
+    z-index: 999;
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    padding: 32px 28px;
+    border-radius: 28px;
+    background: var(--container-bg);
+    box-shadow: 0 24px 56px rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(var(--backdrop-blur));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+}
+
+.dark-mode .auth-overlay {
+    background: rgba(3, 10, 9, 0.82);
+}
+
+.dark-mode .auth-card {
+    background: rgba(32, 32, 32, 0.75);
+    box-shadow: 0 24px 56px rgba(0, 0, 0, 0.45);
+}
+
+.auth-card__logo {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary-color);
+}
+
+.auth-spinner {
+    width: 42px;
+    height: 42px;
+    border-radius: 999px;
+    border: 3px solid rgba(26, 188, 156, 0.25);
+    border-top-color: var(--primary-color);
+    animation: auth-spinner-rotate 0.9s linear infinite;
+    margin: 16px auto 8px;
+}
+
+.auth-overlay[data-state="form"] .auth-spinner[hidden] {
+    display: none !important;
+}
+
+.auth-overlay[data-state="checking"] .auth-form {
+    display: none;
+}
+
+.auth-message {
+    margin: 0;
+    font-size: 15px;
+    color: var(--text-secondary-color);
+    line-height: 1.6;
+}
+
+.auth-form {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.auth-form.is-busy {
+    opacity: 0.75;
+}
+
+.auth-label {
+    font-size: 13px;
+    font-weight: 600;
+    text-align: left;
+    color: var(--text-secondary-color);
+}
+
+.auth-input {
+    width: 100%;
+    padding: 12px 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    background: rgba(255, 255, 255, 0.85);
+    font-size: 16px;
+    color: var(--text-color);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.dark-mode .auth-input {
+    background: rgba(20, 20, 20, 0.85);
+    border-color: rgba(255, 255, 255, 0.08);
+    color: var(--text-color);
+}
+
+.auth-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(26, 188, 156, 0.2);
+}
+
+.auth-submit-btn {
+    width: 100%;
+    padding: 14px 18px;
+    border: none;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--primary-color), var(--primary-color-dark));
+    color: #ffffff;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.auth-submit-btn:hover,
+.auth-submit-btn:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(26, 188, 156, 0.3);
+}
+
+.auth-submit-btn:active {
+    transform: translateY(0);
+    box-shadow: none;
+}
+
+.auth-error {
+    min-height: 20px;
+    margin: 4px 0 0;
+    color: var(--warning-color);
+    font-size: 14px;
+}
+
+.noscript-message {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: #0f0f0f;
+    color: #ffffff;
+    font-size: 16px;
+    text-align: center;
+    z-index: 1000;
+}
+
+@keyframes auth-spinner-rotate {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 600px) {
+    .auth-card {
+        padding: 28px 22px;
+        border-radius: 24px;
+    }
+
+    .auth-card__logo {
+        font-size: 24px;
+    }
+
+    .auth-message {
+        font-size: 14px;
+    }
+
+    .auth-input,
+    .auth-submit-btn {
+        font-size: 15px;
+    }
+}
+
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: var(--scrollbar-track-bg); }
 ::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb-bg); border-radius: 3px; }
@@ -96,6 +277,27 @@ body {
     color: var(--text-color);
     transition: color 0.5s;
     background-color: #0f0f0f;
+}
+
+#mainContainer {
+    transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+body.auth-locked {
+    overflow: hidden;
+}
+
+body.auth-locked #mainContainer {
+    opacity: 0;
+    pointer-events: none;
+    user-select: none;
+    transform: translateY(12px) scale(0.99);
+}
+
+body.auth-ready #mainContainer {
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
 }
 
 .background-stage {

--- a/css/style.css
+++ b/css/style.css
@@ -114,30 +114,13 @@
     box-shadow: 0 24px 56px rgba(0, 0, 0, 0.45);
 }
 
+
 .auth-card__logo {
     font-size: 28px;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--primary-color);
-}
-
-.auth-spinner {
-    width: 42px;
-    height: 42px;
-    border-radius: 999px;
-    border: 3px solid rgba(26, 188, 156, 0.25);
-    border-top-color: var(--primary-color);
-    animation: auth-spinner-rotate 0.9s linear infinite;
-    margin: 16px auto 8px;
-}
-
-.auth-overlay[data-state="form"] .auth-spinner[hidden] {
-    display: none !important;
-}
-
-.auth-overlay[data-state="checking"] .auth-form {
-    display: none;
 }
 
 .auth-message {
@@ -151,8 +134,9 @@
     width: 100%;
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 16px;
-    margin-top: 8px;
+    margin-top: 12px;
 }
 
 .auth-form.is-busy {
@@ -160,6 +144,7 @@
 }
 
 .auth-label {
+    display: block;
     font-size: 13px;
     font-weight: 600;
     text-align: left;
@@ -175,6 +160,7 @@
     font-size: 16px;
     color: var(--text-color);
     transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    box-sizing: border-box;
 }
 
 .dark-mode .auth-input {
@@ -232,12 +218,6 @@
     font-size: 16px;
     text-align: center;
     z-index: 1000;
-}
-
-@keyframes auth-spinner-rotate {
-    to {
-        transform: rotate(360deg);
-    }
 }
 
 @media (max-width: 600px) {

--- a/functions/auth.ts
+++ b/functions/auth.ts
@@ -1,0 +1,178 @@
+const COOKIE_NAME = 'solara_auth';
+const COOKIE_MAX_AGE = 60 * 60 * 12; // 12 hours
+
+interface Env {
+  ACCESS_PASSWORD?: string;
+}
+
+type JsonBody = {
+  passwordRequired: boolean;
+  authenticated: boolean;
+  error?: string;
+};
+
+function jsonResponse(body: JsonBody, init?: ResponseInit): Response {
+  const headers = new Headers(init?.headers);
+  headers.set('Content-Type', 'application/json; charset=utf-8');
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers,
+  });
+}
+
+function parseCookies(cookieHeader: string | null): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  if (!cookieHeader) {
+    return cookies;
+  }
+  const pairs = cookieHeader.split(';');
+  for (const pair of pairs) {
+    const [rawKey, ...rest] = pair.trim().split('=');
+    if (!rawKey) continue;
+    cookies[decodeURIComponent(rawKey)] = decodeURIComponent(rest.join('=') ?? '');
+  }
+  return cookies;
+}
+
+async function createToken(secret: string): Promise<string> {
+  const data = new TextEncoder().encode(`solara:${secret}`);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  const bytes = Array.from(new Uint8Array(digest));
+  return bytes.map((value) => value.toString(16).padStart(2, '0')).join('');
+}
+
+function buildCookie(value: string, url: URL, options?: { expires?: Date; maxAge?: number }): string {
+  const parts = [
+    `${COOKIE_NAME}=${value}`,
+    'Path=/',
+    `Max-Age=${options?.maxAge ?? COOKIE_MAX_AGE}`,
+    'SameSite=Strict',
+    'HttpOnly',
+  ];
+  if (url.protocol === 'https:') {
+    parts.push('Secure');
+  }
+  if (options?.expires) {
+    parts.push(`Expires=${options.expires.toUTCString()}`);
+  }
+  return parts.join('; ');
+}
+
+function clearCookie(url: URL): string {
+  const pastDate = new Date(0);
+  return buildCookie('', url, { expires: pastDate, maxAge: 0 });
+}
+
+export async function onRequest({
+  request,
+  env,
+}: {
+  request: Request;
+  env: Env;
+}): Promise<Response> {
+  const password = env.ACCESS_PASSWORD;
+  const url = new URL(request.url);
+
+  if (!password) {
+    return jsonResponse(
+      {
+        passwordRequired: false,
+        authenticated: true,
+      },
+      {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    );
+  }
+
+  const expectedToken = await createToken(password);
+  const cookies = parseCookies(request.headers.get('Cookie'));
+  const existingToken = cookies[COOKIE_NAME];
+  const isAuthenticated = existingToken === expectedToken;
+
+  if (request.method === 'GET') {
+    const headers = new Headers({
+      'Cache-Control': 'no-store',
+    });
+
+    if (!isAuthenticated && existingToken) {
+      headers.append('Set-Cookie', clearCookie(url));
+    }
+
+    return jsonResponse(
+      {
+        passwordRequired: true,
+        authenticated: isAuthenticated,
+      },
+      { headers },
+    );
+  }
+
+  if (request.method !== 'POST') {
+    return jsonResponse(
+      {
+        passwordRequired: true,
+        authenticated: false,
+        error: '不支持的请求方法。',
+      },
+      { status: 405 },
+    );
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.error('[Solara] Failed to parse auth payload.', error);
+    return jsonResponse(
+      {
+        passwordRequired: true,
+        authenticated: false,
+        error: '请求格式不正确。',
+      },
+      { status: 400 },
+    );
+  }
+
+  const providedPassword =
+    typeof (payload as { password?: unknown }).password === 'string'
+      ? ((payload as { password: string }).password || '').trim()
+      : '';
+
+  if (!providedPassword) {
+    return jsonResponse(
+      {
+        passwordRequired: true,
+        authenticated: false,
+        error: '请输入访问密码。',
+      },
+      { status: 400 },
+    );
+  }
+
+  if (providedPassword !== password) {
+    return jsonResponse(
+      {
+        passwordRequired: true,
+        authenticated: false,
+        error: '密码不正确。',
+      },
+      { status: 401 },
+    );
+  }
+
+  const headers = new Headers({
+    'Cache-Control': 'no-store',
+    'Set-Cookie': buildCookie(expectedToken, url),
+  });
+
+  return jsonResponse(
+    {
+      passwordRequired: true,
+      authenticated: true,
+    },
+    { headers },
+  );
+}

--- a/index.html
+++ b/index.html
@@ -70,8 +70,7 @@
     <div id="authOverlay" class="auth-overlay" data-state="checking" hidden>
         <div class="auth-card" role="dialog" aria-modal="true" aria-labelledby="authMessage">
             <div class="auth-card__logo" aria-hidden="true">Solara</div>
-            <div class="auth-spinner" id="authSpinner" aria-hidden="true"></div>
-            <p id="authMessage" class="auth-message">正在检查访问权限...</p>
+            <p id="authMessage" class="auth-message">站点已设置访问密码，请输入以继续访问。</p>
             <form id="authForm" class="auth-form" novalidate>
                 <label class="auth-label" for="authPassword">访问密码</label>
                 <input

--- a/index.html
+++ b/index.html
@@ -66,7 +66,31 @@
         })();
     </script>
 </head>
-<body>
+<body class="auth-locked">
+    <div id="authOverlay" class="auth-overlay" data-state="checking" hidden>
+        <div class="auth-card" role="dialog" aria-modal="true" aria-labelledby="authMessage">
+            <div class="auth-card__logo" aria-hidden="true">Solara</div>
+            <div class="auth-spinner" id="authSpinner" aria-hidden="true"></div>
+            <p id="authMessage" class="auth-message">正在检查访问权限...</p>
+            <form id="authForm" class="auth-form" novalidate>
+                <label class="auth-label" for="authPassword">访问密码</label>
+                <input
+                    id="authPassword"
+                    class="auth-input"
+                    type="password"
+                    name="password"
+                    placeholder="输入密码"
+                    autocomplete="current-password"
+                    required
+                >
+                <button type="submit" class="auth-submit-btn">进入 Solara</button>
+            </form>
+            <p id="authError" class="auth-error" role="alert" hidden></p>
+        </div>
+    </div>
+    <noscript>
+        <div class="noscript-message">Solara 需要启用 JavaScript 才能正常工作。</div>
+    </noscript>
     <div class="background-stage" id="backgroundStage" aria-hidden="true">
         <div class="background-stage__layer background-stage__layer--base" id="backgroundBaseLayer"></div>
         <div class="background-stage__layer background-stage__layer--transition" id="backgroundTransitionLayer"></div>
@@ -285,6 +309,7 @@
 <!-- 调试信息容器 -->
 <div id="debugInfo" class="debug-info"></div>
 
+<script src="js/auth.js"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="js/index.js"></script>
 <script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,150 @@
+(function () {
+    const overlay = document.getElementById('authOverlay');
+    const mainContainer = document.getElementById('mainContainer');
+    const form = document.getElementById('authForm');
+    const passwordInput = document.getElementById('authPassword');
+    const errorMessage = document.getElementById('authError');
+    const message = document.getElementById('authMessage');
+    const spinner = document.getElementById('authSpinner');
+    const submitButton = form.querySelector('button[type="submit"]');
+
+    if (!overlay || !mainContainer || !form || !passwordInput || !errorMessage || !message || !spinner || !submitButton) {
+        document.body.classList.remove('auth-locked');
+        return;
+    }
+
+    let checking = false;
+
+    const setOverlayState = (state) => {
+        if (!overlay) return;
+        if (state === 'hidden') {
+            overlay.hidden = true;
+            overlay.dataset.state = '';
+        } else {
+            overlay.hidden = false;
+            overlay.dataset.state = state;
+        }
+    };
+
+    const setBusy = (isBusy) => {
+        checking = isBusy;
+        form.classList.toggle('is-busy', isBusy);
+        passwordInput.disabled = isBusy;
+        submitButton.disabled = isBusy;
+    };
+
+    const showError = (text) => {
+        if (!text) {
+            errorMessage.textContent = '';
+            errorMessage.hidden = true;
+            return;
+        }
+        errorMessage.textContent = text;
+        errorMessage.hidden = false;
+    };
+
+    const unlockApp = () => {
+        document.body.classList.remove('auth-locked');
+        document.body.classList.add('auth-ready');
+        mainContainer.removeAttribute('aria-hidden');
+        setOverlayState('hidden');
+    };
+
+    const focusPasswordInput = () => {
+        window.setTimeout(() => {
+            passwordInput.focus({ preventScroll: true });
+        }, 50);
+    };
+
+    const checkStatus = async () => {
+        mainContainer.setAttribute('aria-hidden', 'true');
+        document.body.classList.add('auth-locked');
+        setOverlayState('checking');
+        showError('');
+        message.textContent = '正在检查访问权限...';
+        spinner.removeAttribute('hidden');
+
+        try {
+            const response = await fetch('/auth', { credentials: 'include' });
+            if (!response.ok) {
+                throw new Error('AUTH_STATUS_ERROR');
+            }
+            const payload = await response.json();
+            if (!payload || typeof payload !== 'object') {
+                throw new Error('AUTH_STATUS_INVALID');
+            }
+            const { passwordRequired, authenticated } = payload;
+            if (!passwordRequired || authenticated) {
+                unlockApp();
+                return;
+            }
+            setOverlayState('form');
+            spinner.setAttribute('hidden', '');
+            message.textContent = '站点已设置访问密码，请输入以继续访问。';
+            focusPasswordInput();
+        } catch (error) {
+            console.error('[Solara] Failed to verify password status.', error);
+            setOverlayState('form');
+            spinner.setAttribute('hidden', '');
+            message.textContent = '无法连接到验证服务，请稍后重试。';
+            focusPasswordInput();
+        }
+    };
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (checking) return;
+
+        const password = passwordInput.value.trim();
+        if (!password) {
+            showError('请输入访问密码。');
+            focusPasswordInput();
+            return;
+        }
+
+        showError('');
+        setBusy(true);
+        setOverlayState('form');
+        spinner.removeAttribute('hidden');
+        message.textContent = '正在验证访问密码...';
+
+        try {
+            const response = await fetch('/auth', {
+                method: 'POST',
+                credentials: 'include',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ password }),
+            });
+
+            const payload = await response.json().catch(() => ({}));
+            const { authenticated, error: authError } = payload;
+
+            if (!response.ok || !authenticated) {
+                spinner.setAttribute('hidden', '');
+                message.textContent = '站点已设置访问密码，请输入以继续访问。';
+                const errorText =
+                    typeof authError === 'string' && authError.trim()
+                        ? authError.trim()
+                        : '密码不正确，请重试。';
+                showError(errorText);
+                focusPasswordInput();
+                passwordInput.select();
+                return;
+            }
+
+            unlockApp();
+        } catch (error) {
+            console.error('[Solara] Failed to authenticate.', error);
+            spinner.setAttribute('hidden', '');
+            message.textContent = '验证过程中出现问题，请稍后重试。';
+            showError('验证过程中出现问题，请稍后重试。');
+            focusPasswordInput();
+        } finally {
+            setBusy(false);
+        }
+    });
+
+    checkStatus();
+})();

--- a/js/auth.js
+++ b/js/auth.js
@@ -5,15 +5,29 @@
     const passwordInput = document.getElementById('authPassword');
     const errorMessage = document.getElementById('authError');
     const message = document.getElementById('authMessage');
-    const spinner = document.getElementById('authSpinner');
     const submitButton = form.querySelector('button[type="submit"]');
 
-    if (!overlay || !mainContainer || !form || !passwordInput || !errorMessage || !message || !spinner || !submitButton) {
+    if (!overlay || !mainContainer || !form || !passwordInput || !errorMessage || !message || !submitButton) {
         document.body.classList.remove('auth-locked');
         return;
     }
 
     let checking = false;
+    const promptMessage = '站点已设置访问密码，请输入以继续访问。';
+
+    mainContainer.setAttribute('aria-hidden', 'true');
+
+    const toBoolean = (value) => {
+        if (typeof value === 'boolean') {
+            return value;
+        }
+        if (typeof value === 'string') {
+            const normalized = value.trim().toLowerCase();
+            if (normalized === 'true') return true;
+            if (normalized === 'false') return false;
+        }
+        return Boolean(value);
+    };
 
     const setOverlayState = (state) => {
         if (!overlay) return;
@@ -33,6 +47,12 @@
         submitButton.disabled = isBusy;
     };
 
+    const lockApp = () => {
+        document.body.classList.remove('auth-ready');
+        document.body.classList.add('auth-locked');
+        mainContainer.setAttribute('aria-hidden', 'true');
+    };
+
     const showError = (text) => {
         if (!text) {
             errorMessage.textContent = '';
@@ -50,6 +70,12 @@
         setOverlayState('hidden');
     };
 
+    const showPrompt = (text) => {
+        lockApp();
+        message.textContent = text || promptMessage;
+        setOverlayState('form');
+    };
+
     const focusPasswordInput = () => {
         window.setTimeout(() => {
             passwordInput.focus({ preventScroll: true });
@@ -57,36 +83,42 @@
     };
 
     const checkStatus = async () => {
-        mainContainer.setAttribute('aria-hidden', 'true');
-        document.body.classList.add('auth-locked');
-        setOverlayState('checking');
         showError('');
-        message.textContent = '正在检查访问权限...';
-        spinner.removeAttribute('hidden');
 
         try {
             const response = await fetch('/auth', { credentials: 'include' });
+            if (response.status === 404) {
+                unlockApp();
+                return;
+            }
+
+            const payload = await response
+                .clone()
+                .json()
+                .catch(() => null);
+
             if (!response.ok) {
                 throw new Error('AUTH_STATUS_ERROR');
             }
-            const payload = await response.json();
+
             if (!payload || typeof payload !== 'object') {
-                throw new Error('AUTH_STATUS_INVALID');
+                unlockApp();
+                return;
             }
-            const { passwordRequired, authenticated } = payload;
+
+            const passwordRequired = toBoolean(payload.passwordRequired);
+            const authenticated = toBoolean(payload.authenticated);
+
             if (!passwordRequired || authenticated) {
                 unlockApp();
                 return;
             }
-            setOverlayState('form');
-            spinner.setAttribute('hidden', '');
-            message.textContent = '站点已设置访问密码，请输入以继续访问。';
+
+            showPrompt();
             focusPasswordInput();
         } catch (error) {
             console.error('[Solara] Failed to verify password status.', error);
-            setOverlayState('form');
-            spinner.setAttribute('hidden', '');
-            message.textContent = '无法连接到验证服务，请稍后重试。';
+            showPrompt('无法连接到验证服务，请稍后重试。');
             focusPasswordInput();
         }
     };
@@ -104,9 +136,7 @@
 
         showError('');
         setBusy(true);
-        setOverlayState('form');
-        spinner.removeAttribute('hidden');
-        message.textContent = '正在验证访问密码...';
+        showPrompt();
 
         try {
             const response = await fetch('/auth', {
@@ -122,8 +152,7 @@
             const { authenticated, error: authError } = payload;
 
             if (!response.ok || !authenticated) {
-                spinner.setAttribute('hidden', '');
-                message.textContent = '站点已设置访问密码，请输入以继续访问。';
+                showPrompt();
                 const errorText =
                     typeof authError === 'string' && authError.trim()
                         ? authError.trim()
@@ -137,8 +166,7 @@
             unlockApp();
         } catch (error) {
             console.error('[Solara] Failed to authenticate.', error);
-            spinner.setAttribute('hidden', '');
-            message.textContent = '验证过程中出现问题，请稍后重试。';
+            showPrompt('验证过程中出现问题，请稍后重试。');
             showError('验证过程中出现问题，请稍后重试。');
             focusPasswordInput();
         } finally {


### PR DESCRIPTION
## Summary
- add a Solara-themed login overlay and supporting script that checks Cloudflare auth status before revealing the app
- implement a Cloudflare Pages Function that validates an optional ACCESS_PASSWORD and issues a secure session cookie
- document how to enable the optional password via the ACCESS_PASSWORD environment variable

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68f3d54db8f8832bbc13d93df4a92791