### PR TITLE
Add multi-select import for search results and refresh controls

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -805,6 +805,22 @@ body.mobile-view .search-area .search-results {
     align-self: center;
 }
 
+body.mobile-view .search-results-toolbar {
+    width: min(100%, 340px);
+    margin: 0 auto;
+    padding-top: 8px;
+}
+
+body.mobile-view .import-selected-btn {
+    width: 100%;
+    justify-content: center;
+}
+
+body.mobile-view .search-results-list {
+    width: min(100%, 340px);
+    margin: 0 auto;
+}
+
 body.mobile-view .search-area > :not(.mobile-close-btn) {
     width: min(100%, 360px);
     align-self: center;

--- a/css/style.css
+++ b/css/style.css
@@ -402,6 +402,24 @@ body.background-transitioning .background-stage__layer--transition {
     border-radius: 0 0 14px 14px;
     flex: 1;
     min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.search-results-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+    padding-top: 12px;
+}
+
+.search-results-list {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 }
 
 /* 搜索模式下的搜索结果 */
@@ -419,7 +437,7 @@ body.background-transitioning .background-stage__layer--transition {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px;
+    padding: 12px 16px;
     border-radius: 12px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -431,6 +449,7 @@ body.background-transitioning .background-stage__layer--transition {
     transform: translateY(20px);
     opacity: 0;
     animation: slideInUp 0.4s ease forwards;
+    gap: 14px;
 }
 
 .search-result-item:nth-child(1) { animation-delay: 0.1s; }
@@ -446,10 +465,65 @@ body.background-transitioning .background-stage__layer--transition {
     }
 }
 
-.search-result-item:hover {
+.search-result-item:hover:not(.selected) {
     background: var(--item-hover-bg);
     transform: translateY(-2px);
     box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+}
+
+.search-result-item.selected {
+    background: var(--item-current-bg);
+    border-color: var(--primary-color);
+    box-shadow: 0 12px 28px rgba(26, 188, 156, 0.25);
+    transform: translateY(0);
+}
+
+.search-result-item.selected .search-result-title {
+    color: var(--primary-color);
+}
+
+.search-result-item.selected .search-result-select {
+    border-color: var(--primary-color);
+    background: var(--primary-color);
+    color: #ffffff;
+    box-shadow: 0 6px 16px rgba(26, 188, 156, 0.35);
+}
+
+.search-result-item.selected .search-result-select i {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.search-result-select {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.65);
+    color: transparent;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.search-result-select i {
+    opacity: 0;
+    transform: scale(0.6);
+    transition: all 0.2s ease;
+    pointer-events: none;
+}
+
+.search-result-select:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(26, 188, 156, 0.35);
+}
+
+.search-result-item .search-result-select:hover {
+    border-color: var(--primary-color);
 }
 
 .search-result-info {
@@ -479,6 +553,44 @@ body.background-transitioning .background-stage__layer--transition {
     display: flex;
     gap: 8px;
     margin-left: 15px;
+}
+
+.import-selected-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: none;
+    border-radius: 999px;
+    padding: 8px 16px;
+    background: var(--primary-color);
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    box-shadow: 0 10px 24px rgba(26, 188, 156, 0.25);
+}
+
+.import-selected-btn:disabled {
+    cursor: not-allowed;
+    background: rgba(127, 140, 141, 0.5);
+    box-shadow: none;
+    filter: none;
+}
+
+.import-selected-btn:not(:disabled):hover,
+.import-selected-btn:not(:disabled):focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 30px rgba(26, 188, 156, 0.32);
+    filter: brightness(1.05);
+}
+
+.import-selected-btn:focus-visible {
+    outline: none;
+}
+
+.import-selected-count {
+    font-weight: 500;
 }
 
 .action-btn {
@@ -678,37 +790,41 @@ html.mobile-view .playlist-label {
     pointer-events: auto;
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 6px 10px;
-    border-radius: 999px;
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    background: rgba(255, 255, 255, 0.78);
-    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
-    backdrop-filter: blur(18px);
-    -webkit-backdrop-filter: blur(18px);
-    transition: box-shadow 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    box-shadow: none;
 }
 
 body.dark-mode .playlist-actions-tray {
-    background: rgba(20, 24, 33, 0.78);
-    border-color: rgba(255, 255, 255, 0.08);
-    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+    background: transparent;
+    border: none;
+    box-shadow: none;
 }
 
 .playlist-action-btn {
-    width: 34px;
-    height: 34px;
+    width: 40px;
+    height: 40px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    border: none;
-    background: transparent;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(255, 255, 255, 0.75);
     color: var(--text-secondary-color);
     font-size: 15px;
     cursor: pointer;
-    transition: color 0.25s ease, background 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
-    box-shadow: inset 0 0 0 1px transparent;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, border-color 0.2s ease;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+}
+
+body.dark-mode .playlist-action-btn {
+    background: rgba(24, 30, 40, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+    color: var(--text-secondary-color);
 }
 
 .playlist-action-btn i {
@@ -717,10 +833,11 @@ body.dark-mode .playlist-actions-tray {
 
 .playlist-action-btn:hover:not(:disabled),
 .playlist-action-btn:focus-visible:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 30px rgba(26, 188, 156, 0.25);
+    filter: brightness(1.06);
+    border-color: rgba(26, 188, 156, 0.4);
     color: var(--primary-color);
-    background: rgba(26, 188, 156, 0.12);
-    box-shadow: inset 0 0 0 1px rgba(26, 188, 156, 0.35), 0 6px 16px rgba(26, 188, 156, 0.25);
-    transform: translateY(-1px);
 }
 
 .playlist-action-btn:focus-visible {
@@ -734,20 +851,22 @@ body.dark-mode .playlist-actions-tray {
 
 .playlist-action-btn--clear {
     color: rgba(231, 76, 60, 0.85);
+    border-color: rgba(231, 76, 60, 0.28);
 }
 
 .playlist-action-btn--clear:hover:not(:disabled),
 .playlist-action-btn--clear:focus-visible:not(:disabled) {
-    background: rgba(231, 76, 60, 0.16);
-    box-shadow: inset 0 0 0 1px rgba(231, 76, 60, 0.35), 0 8px 18px rgba(231, 76, 60, 0.28);
+    filter: brightness(1.05);
+    box-shadow: 0 16px 32px rgba(231, 76, 60, 0.28);
     color: var(--warning-color);
 }
 
 .playlist-action-btn:disabled {
-    opacity: 0.45;
+    opacity: 0.5;
     cursor: not-allowed;
     transform: none;
     box-shadow: none;
+    filter: none;
 }
 
 .playlist-action-btn:disabled:hover {

--- a/index.html
+++ b/index.html
@@ -112,7 +112,16 @@
                     <span>搜索</span>
                 </button>
             </div>
-            <div id="searchResults" class="search-results"></div>
+            <div id="searchResults" class="search-results">
+                <div class="search-results-toolbar">
+                    <button id="importSelectedBtn" class="import-selected-btn" type="button" disabled>
+                        <i class="fas fa-file-import" aria-hidden="true"></i>
+                        <span class="import-selected-label">导入已选</span>
+                        <span id="importSelectedCount" class="import-selected-count" aria-hidden="true"></span>
+                    </button>
+                </div>
+                <div id="searchResultsList" class="search-results-list"></div>
+            </div>
         </div>
 
         <div class="main-content">


### PR DESCRIPTION
## Summary
- add multi-select support to the search results list with a toolbar button for importing selected songs into the playlist
- keep single-song playback/import behavior intact while updating search row interactions and styling for selected states
- refresh the playlist import/export/clear controls with modern circular buttons and adjust related styling for desktop and mobile layouts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f599fa9fc0832b98a927db1b165b6d