### PR TITLE
Ensure mobile search close exits search mode

### DIFF
--- a/js/mobile.js
+++ b/js/mobile.js
@@ -53,6 +53,12 @@
             return;
         }
         document.body.classList.remove("mobile-search-open");
+        const toggleSearchMode = window.toggleSearchMode;
+        if (typeof toggleSearchMode === "function") {
+            toggleSearchMode(false);
+        } else if (typeof window.hideSearchResults === "function") {
+            window.hideSearchResults();
+        }
         if (dom.searchArea) {
             dom.searchArea.setAttribute("aria-hidden", "true");
         }
@@ -85,11 +91,8 @@
         if (typeof window.switchMobileView === "function") {
             window.switchMobileView(targetView);
         }
+        closeMobileSearchImpl();
         document.body.classList.add("mobile-panel-open");
-        document.body.classList.remove("mobile-search-open");
-        if (dom.searchArea) {
-            dom.searchArea.setAttribute("aria-hidden", "true");
-        }
         document.body.setAttribute("data-mobile-panel-view", targetView);
         updateMobileOverlayScrim();
     }


### PR DESCRIPTION
## Summary
- exit mobile search mode when the overlay is closed so the container resets correctly
- reuse the centralized close logic when opening the mobile panel to avoid stale mobile-search classes

## Testing
- Manual verification on a simulated mobile viewport via Playwright

------
https://chatgpt.com/codex/tasks/task_b_68f5b9109d70832b8279d07f99da7c5f