### PR TITLE
Float desktop search import button without overlay

### DIFF
--- a/css/desktop.css
+++ b/css/desktop.css
@@ -74,7 +74,11 @@ html.desktop-view .search-results-toolbar {
 
 html.desktop-view .search-results-toolbar .import-selected-btn {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 16px;
+    right: 20px;
     pointer-events: auto;
+}
+
+html.desktop-view .search-results-list {
+    padding-top: 60px;
 }

--- a/css/desktop.css
+++ b/css/desktop.css
@@ -10,3 +10,71 @@ html.desktop-view .mobile-turntable__label,
 html.desktop-view .mobile-inline-lyrics {
     display: none;
 }
+
+/* Remove circular decoration from playlist action buttons on desktop */
+html.desktop-view .playlist-action-btn {
+    width: auto;
+    height: auto;
+    padding: 6px;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    box-shadow: none;
+    color: var(--text-secondary-color);
+    transition: color 0.2s ease;
+}
+
+html.desktop-view body.dark-mode .playlist-action-btn {
+    background: none;
+    border: none;
+    box-shadow: none;
+    color: var(--text-secondary-color);
+}
+
+html.desktop-view .playlist-action-btn:hover:not(:disabled),
+html.desktop-view .playlist-action-btn:focus-visible:not(:disabled) {
+    transform: none;
+    box-shadow: none;
+    filter: none;
+    border: none;
+    color: var(--primary-color);
+}
+
+html.desktop-view .playlist-action-btn--clear {
+    color: rgba(231, 76, 60, 0.85);
+}
+
+html.desktop-view .playlist-action-btn--clear:hover:not(:disabled),
+html.desktop-view .playlist-action-btn--clear:focus-visible:not(:disabled) {
+    color: var(--warning-color);
+}
+
+html.desktop-view .playlist-action-btn:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+html.desktop-view .playlist-action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+/* Keep the desktop search import button visible without an opaque bar */
+html.desktop-view .search-results {
+    gap: 0;
+}
+
+html.desktop-view .search-results-toolbar {
+    display: block;
+    padding: 0;
+    height: 0;
+    overflow: visible;
+    pointer-events: none;
+}
+
+html.desktop-view .search-results-toolbar .import-selected-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    pointer-events: auto;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -413,6 +413,11 @@ body.background-transitioning .background-stage__layer--transition {
     align-items: center;
     gap: 8px;
     padding-top: 12px;
+    padding-bottom: 12px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: none;
 }
 
 .search-results-list {


### PR DESCRIPTION
## Summary
- collapse the desktop search results toolbar spacing so only the “导入已选” control stays visible
- float the import button above the list with pointer-event fixes so it no longer leaves a white mask while scrolling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f6e519341c832b99837947145444c3