### PR TITLE
Center mobile login layout independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@
 - 🔗 API 基地址定义在 index.html 中的 `API.baseUrl`（约 1300 行），可替换为自建接口域名。
 - 🎚️ 默认主题、播放模式等偏好可在 `state` 初始化逻辑中按需调整。
 
-## 🔐 访问控制建议
-- 若希望为站点加密访问，可在 Cloudflare Pages 站点设置中启用 **访问策略**，随后点击“管理”跳转至 Cloudflare Zero Trust。
-- 在 Zero Trust 控制台中新建策略，设置登录验证并限制仅允许特定邮箱访问。
-- 详细步骤可参考指南：https://blog.galois21.com/archives/2360 。
-- 配置了策略一定要在Zero Trust-应用程序里确认是否绑定 不绑定不生效
+## 🔐 访问控制设置
+- 在 Cloudflare Pages 项目的 **Settings → Functions → Environment variables** 中新增名为 `PASSWORD` 的环境变量，值为希望设置的访问口令。
+- 变量保存后重新部署站点，未登录的访问者会被自动重定向到 `/login` 页面并需输入该口令。
+- 若后续想关闭访问口令，只需在同一位置删除 `PASSWORD` 环境变量并重新部署。
 ## 🎵 使用流程
 1. 输入关键词并选择想要的曲库后发起搜索。
 2. 在结果列表中可试听、播放、下载或加入播放队列。

--- a/login.html
+++ b/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" class="login-page-root">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -36,43 +36,118 @@
       document.head.appendChild(link);
       const setViewportUnit = () => {
         const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
-        document.documentElement.style.setProperty("--mobile-vh", `${viewportHeight}px`);
+        if (typeof viewportHeight === "number" && !Number.isNaN(viewportHeight)) {
+          document.documentElement.style.setProperty("--mobile-vh", `${viewportHeight}px`);
+        }
+      };
+      const updateLoginLayout = () => {
+        const body = document.body;
+        const viewport = window.visualViewport;
+        const rawWidth = viewport ? viewport.width : window.innerWidth;
+        const hasNumericWidth = typeof rawWidth === "number" && !Number.isNaN(rawWidth);
+        const fallbackWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+        const width = hasNumericWidth ? rawWidth : fallbackWidth;
+        const orientationQuery = typeof window.matchMedia === "function" ? window.matchMedia("(orientation: portrait)") : null;
+        const isPortrait = orientationQuery ? orientationQuery.matches : window.innerHeight >= window.innerWidth;
+        const isNarrow = width <= 820;
+        if (body) {
+          body.classList.toggle("portrait-mobile", Boolean(isPortrait && isNarrow));
+        }
+        let scale = 1;
+        if (width) {
+          if (isPortrait && width < 430) {
+            scale = Math.min(1, Math.max(0.8, width / 430));
+          } else if (!isPortrait && width < 540) {
+            scale = Math.min(1, Math.max(0.85, width / 540));
+          }
+        }
+        document.documentElement.style.setProperty("--login-scale", scale.toFixed(4));
+      };
+      const handleLayoutChange = () => {
+        setViewportUnit();
+        updateLoginLayout();
       };
       const applyBodyClass = () => {
         if (document.body) {
           document.body.classList.add("mobile-view");
-          setViewportUnit();
         }
+        handleLayoutChange();
       };
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", applyBodyClass, { once: true });
       } else {
         applyBodyClass();
       }
-      window.addEventListener("resize", setViewportUnit);
-      window.addEventListener("orientationchange", setViewportUnit);
+      window.addEventListener("resize", handleLayoutChange);
+      window.addEventListener("orientationchange", handleLayoutChange);
       if (window.visualViewport) {
-        window.visualViewport.addEventListener("resize", setViewportUnit);
-        window.visualViewport.addEventListener("scroll", setViewportUnit);
+        window.visualViewport.addEventListener("resize", handleLayoutChange);
+        window.visualViewport.addEventListener("scroll", handleLayoutChange);
       }
-      setViewportUnit();
+      handleLayoutChange();
     })();
   </script>
   <style>
-    body {
+    :root {
+      --login-scale: 1;
+    }
+
+    html.login-page-root {
+      min-height: var(--mobile-vh, 100dvh);
+      height: auto;
+    }
+
+    html.login-page-root,
+    body.login-page {
+      overflow-x: hidden;
+    }
+
+    html.login-page-root.mobile-view {
+      height: auto;
+      overflow-y: auto;
+    }
+
+    body.login-page {
       position: relative;
       margin: 0;
       padding: clamp(16px, 4vw, 40px);
       font-family: 'Noto Sans SC', 'Segoe UI', Arial, sans-serif;
       display: flex;
-      justify-content: center;
-      align-items: center;
+      justify-content: center !important;
+      align-items: center !important;
       min-height: var(--mobile-vh, 100dvh);
       color: var(--text-color);
       background: radial-gradient(circle at 20% 20%, rgba(26, 188, 156, 0.35), transparent 55%),
                   radial-gradient(circle at 80% 0%, rgba(52, 152, 219, 0.28), transparent 50%),
                   #07090f;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+
+    body.login-page.mobile-view {
+      position: static;
+      inset: auto;
+      width: auto;
+      height: auto;
+      min-height: var(--mobile-vh, 100dvh);
+      padding: calc(env(safe-area-inset-top, 0px) + clamp(18px, 6vw, 32px))
+               clamp(18px, 6vw, 32px)
+               calc(env(safe-area-inset-bottom, 0px) + clamp(24px, 7vw, 36px));
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      overflow-y: auto;
+    }
+
+    body.login-page.mobile-view.portrait-mobile {
+      padding: calc(env(safe-area-inset-top, 0px) + clamp(20px, 8vw, 32px))
+               clamp(18px, 7vw, 28px)
+               calc(env(safe-area-inset-bottom, 0px) + clamp(26px, 9vw, 38px));
+    }
+
+    body.login-page.mobile-view .background-stage {
+      display: block;
     }
 
     .background-stage {
@@ -128,6 +203,27 @@
       position: relative;
       width: min(460px, 100%);
       z-index: 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-inline: auto;
+      min-height: calc(var(--mobile-vh, 100dvh) - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+    }
+
+    html.desktop-view .login-shell {
+      min-height: auto;
+    }
+
+    body.login-page.mobile-view .login-shell {
+      width: 100%;
+      max-width: 440px;
+      padding: clamp(18px, 6vw, 28px);
+      min-height: auto;
+      flex: 1 1 auto;
+    }
+
+    body.login-page.mobile-view.portrait-mobile .login-shell {
+      min-height: auto;
     }
 
     .login-container {
@@ -144,6 +240,17 @@
       backdrop-filter: blur(18px);
       -webkit-backdrop-filter: blur(18px);
       color: #f2f6f9;
+      width: 100%;
+      box-sizing: border-box;
+      transform: scale(var(--login-scale));
+      transform-origin: center;
+      transition: transform 0.25s ease;
+      will-change: transform;
+      margin-inline: auto;
+    }
+
+    body.login-page.mobile-view.portrait-mobile .login-container {
+      justify-content: center;
     }
 
     .login-header {
@@ -307,7 +414,7 @@
     }
 
     @media (max-width: 768px) {
-      body {
+      body.login-page {
         padding: clamp(16px, 4vw, 24px);
       }
 
@@ -334,22 +441,23 @@
     }
 
     @media (max-width: 480px) {
-      body {
-        align-items: stretch;
-        padding: max(16px, env(safe-area-inset-top));
+      body.login-page {
+        padding: clamp(16px, 7vw, 24px);
       }
 
-      .login-shell {
-        width: 100%;
-        display: flex;
-        align-items: stretch;
+      body.login-page.mobile-view {
+        padding: calc(env(safe-area-inset-top, 0px) + clamp(16px, 7vw, 24px))
+                 clamp(16px, 7vw, 24px)
+                 calc(env(safe-area-inset-bottom, 0px) + clamp(22px, 8vw, 30px));
       }
 
-      .login-container {
+      body.login-page .login-shell {
         width: 100%;
+        max-width: 420px;
+      }
+
+      body.login-page .login-container {
         padding: clamp(24px, 7vw, 32px);
-        min-height: calc(var(--mobile-vh, 100dvh) - 32px);
-        justify-content: center;
       }
 
       .login-footer {
@@ -360,7 +468,7 @@
     }
   </style>
 </head>
-<body>
+<body class="login-page">
   <div class="background-stage">
     <div class="background-stage__layer"></div>
     <div class="background-stage__overlay"></div>


### PR DESCRIPTION
## Summary
- add a login-page root class so the login view can override the shared mobile layout rules
- override the mobile flex alignment, positioning, and safe-area padding so the login card centers correctly in portrait Safari

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6906548de160832f9406280a180962b1