### PR TITLE
Keep outer login icon square and round inner symbol

### DIFF
--- a/login.html
+++ b/login.html
@@ -277,11 +277,26 @@
       overflow: hidden;
     }
 
-    .logo-circle img {
+    .logo-symbol {
       width: 70%;
-      height: 70%;
+      aspect-ratio: 1;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow:
+        0 10px 24px rgba(82, 233, 210, 0.16),
+        inset 0 0 10px rgba(146, 255, 236, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    .logo-symbol img {
+      width: 68%;
+      height: 68%;
       object-fit: contain;
       filter: brightness(0) invert(1) drop-shadow(0 0 10px rgba(146, 255, 236, 0.6));
+      display: block;
     }
 
     .title-group {
@@ -480,7 +495,9 @@
     <section class="login-container">
       <header class="login-header">
         <div class="logo-circle" aria-hidden="true">
-          <img src="/favicon.svg" alt="">
+          <span class="logo-symbol">
+            <img src="/favicon.svg" alt="">
+          </span>
         </div>
         <div class="title-group">
           <h1 class="login-title">Solara</h1>


### PR DESCRIPTION
## Summary
- restore the login logo container to its original rounded-square border
- wrap the favicon in a new logo-symbol element to display it with rounded-square edges inside the frame

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_69077823d5dc832fb504685fe831b9fd