### PR TITLE
Round favicon corners

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -5,7 +5,13 @@
  width="1024.000000pt" height="1024.000000pt" viewBox="0 0 1024.000000 1024.000000"
  preserveAspectRatio="xMidYMid meet">
 
-<g transform="translate(0.000000,1024.000000) scale(0.100000,-0.100000)"
+<defs>
+<clipPath id="roundedCorners">
+<rect x="0" y="0" width="1024" height="1024" rx="120" ry="120"/>
+</clipPath>
+</defs>
+
+<g clip-path="url(#roundedCorners)" transform="translate(0.000000,1024.000000) scale(0.100000,-0.100000)"
 fill="#000000" stroke="none">
 <path d="M0 5120 l0 -5120 5120 0 5120 0 0 5120 0 5120 -5120 0 -5120 0 0
 -5120z m5162 2773 c17 -15 18 -55 18 -850 0 -718 2 -833 14 -833 17 0 15 -7


### PR DESCRIPTION
## Summary
- add an SVG clip path with rounded corners to the favicon so the edges are curved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69077c40f8d8832fb1df71e3755f4606