### PR TITLE
Center mobile main content between header and controls

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -157,8 +157,9 @@ body.mobile-view .main-content {
     flex-direction: column;
     gap: clamp(16px, 5vw, 28px);
     z-index: 1;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     justify-content: flex-start;
+    margin-block: auto;
     min-height: 0;
 }
 


### PR DESCRIPTION
## Summary
- allow the mobile main content block to absorb extra space for balanced spacing between the header and playback controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_690780795a88832fbd187dd569b9c033