### PR TITLE
Adjust mobile album cover styling

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -218,9 +218,8 @@ body.mobile-view .album-cover {
     border-radius: 50%;
     overflow: hidden;
     box-shadow:
-        inset 0 0 0 3px rgba(0, 0, 0, 0.55),
         0 18px 38px rgba(0, 0, 0, 0.45);
-    background: rgba(0, 0, 0, 0.35);
+    background: transparent;
     z-index: 2;
 }
 


### PR DESCRIPTION
## Summary
- remove the inset inner shadow from the mobile album cover
- make the album cover background transparent to blend smoothly with the base

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6908d45e4b4c832fb624ee0534e9ee98