### PR TITLE
Adjust mobile background opacity

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -51,13 +51,13 @@ body.mobile-view .background-stage {
         -webkit-mask-image: radial-gradient(
             circle at 50% calc(50% + var(--mobile-ring-vertical-shift)),
             transparent calc(var(--mobile-ring-inner-radius)),
-            rgba(0, 0, 0, 0.92) calc(var(--mobile-ring-inner-radius) + var(--mobile-ring-feather)),
+            rgba(0, 0, 0, 1) calc(var(--mobile-ring-inner-radius) + var(--mobile-ring-feather)),
             rgba(0, 0, 0, 1) 100%
         );
         mask-image: radial-gradient(
             circle at 50% calc(50% + var(--mobile-ring-vertical-shift)),
             transparent calc(var(--mobile-ring-inner-radius)),
-            rgba(0, 0, 0, 0.92) calc(var(--mobile-ring-inner-radius) + var(--mobile-ring-feather)),
+            rgba(0, 0, 0, 1) calc(var(--mobile-ring-inner-radius) + var(--mobile-ring-feather)),
             rgba(0, 0, 0, 1) 100%
         );
         -webkit-mask-repeat: no-repeat;
@@ -77,7 +77,7 @@ body.mobile-view .background-stage {
 body.mobile-view .container {
     width: 100%;
     max-width: 420px;
-    background: linear-gradient(180deg, rgba(27, 29, 36, 0.92), rgba(7, 9, 14, 0.95));
+    background: linear-gradient(180deg, rgba(27, 29, 36, 1), rgba(7, 9, 14, 1));
     border-radius: 32px;
     padding: clamp(16px, 5vw, 28px);
     padding-top: calc(env(safe-area-inset-top) + clamp(18px, 6vw, 32px));


### PR DESCRIPTION
## Summary
- increase the radial gradient mask opacity in the mobile background stage
- remove transparency from the mobile container gradient to make it fully opaque

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6908dc89c718832fa7d50881ff8c59b0