### PR TITLE
Adjust mobile album cover layout

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -210,17 +210,17 @@ body.mobile-view .mobile-turntable__platter::before {
 
 body.mobile-view .album-cover {
     position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 58%;
+    top: 0;
+    left: 0;
+    width: 100%;
     aspect-ratio: 1 / 1;
-    transform: translate(-50%, -50%);
-    border-radius: 50%;
+    /* transform: translate(-50%, -50%); */
+    /* border-radius: 50%; */
     overflow: hidden;
     box-shadow:
         inset 0 0 0 3px rgba(0, 0, 0, 0.55),
         0 18px 38px rgba(0, 0, 0, 0.45);
-    background: rgba(0, 0, 0, 0.35);
+    background: transparent;
     z-index: 2;
 }
 
@@ -228,7 +228,7 @@ body.mobile-view .album-cover img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    border-radius: 50%;
+    /* border-radius: 50%; */
 }
 
 body.mobile-view .album-cover .placeholder {


### PR DESCRIPTION
## Summary
- expand the mobile album cover to fill its container and reset the positioning to the top-left
- remove the circular cropping and background fill that caused visible edges when rotated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6908f0d0b030832f8bd223e281b95d21