### PR TITLE
Guard audio ended listener when Media Session is available

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -597,7 +597,17 @@ body.mobile-view .mobile-panel-actions {
     display: inline-flex;
     align-items: center;
     justify-self: end;
-    gap: 10px;
+    gap: 8px;
+}
+
+body.mobile-view .mobile-actions-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+body.mobile-view .mobile-actions-group[hidden] {
+    display: none !important;
 }
 
 body.mobile-view .mobile-panel-action-btn,

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -690,7 +690,7 @@ body.mobile-view .playlist-items {
 }
 
 body.mobile-view .playlist-items .playlist-item {
-    padding: 12px 56px 12px 18px;
+    padding: 12px 108px 12px 18px;
     white-space: normal;
     line-height: 1.35;
     min-height: 0;
@@ -706,6 +706,7 @@ body.mobile-view .playlist-items .playlist-item:hover {
     transform: none;
 }
 
+body.mobile-view .playlist-items .playlist-item .playlist-item-favorite,
 body.mobile-view .playlist-items .playlist-item .playlist-item-download,
 body.mobile-view .playlist-items .playlist-item .playlist-item-remove {
     width: 28px;
@@ -713,12 +714,16 @@ body.mobile-view .playlist-items .playlist-item .playlist-item-remove {
     border-radius: 8px;
 }
 
+body.mobile-view .playlist-items .playlist-item .playlist-item-favorite {
+    right: 88px;
+}
+
 body.mobile-view .playlist-items .playlist-item .playlist-item-download {
-    right: 52px;
+    right: 48px;
 }
 
 body.mobile-view .playlist-items .playlist-item .playlist-item-remove {
-    right: 14px;
+    right: 12px;
 }
 
 body.mobile-view .playlist-items .playlist-item {
@@ -738,6 +743,14 @@ body.mobile-view .playlist-items .playlist-item:hover,
 body.mobile-view .playlist-items .playlist-item.current {
     background: rgba(243, 162, 91, 0.25);
     color: #ffffff;
+}
+
+body.mobile-view .favorites .favorite-item-action {
+    opacity: 1;
+}
+
+body.mobile-view .favorites .favorite-item-action:hover {
+    transform: translateY(-50%);
 }
 
 body.mobile-view .lyrics {

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -580,6 +580,7 @@ body.mobile-view .mobile-panel-header {
     grid-template-columns: 1fr auto;
     align-items: center;
     column-gap: 12px;
+    row-gap: 8px;
     color: #ffffff;
 }
 
@@ -590,12 +591,6 @@ body.mobile-view .mobile-panel-handle {
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.28);
     margin: 0 auto 10px;
-}
-
-body.mobile-view .mobile-panel-title {
-    font-size: 1.05rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
 }
 
 body.mobile-view .mobile-panel-actions {

--- a/css/style.css
+++ b/css/style.css
@@ -1920,6 +1920,8 @@ input[type="range"]:active::-moz-range-thumb {
     font-size: 12px;
     z-index: 10000;
     max-width: 300px;
+    max-height: 40vh;
+    overflow-y: auto;
     display: none;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1248,20 +1248,23 @@ html.mobile-view .playlist-header .playlist-action-btn {
     box-shadow: 0 4px 10px rgba(231, 76, 60, 0.22);
 }
 
-.playlist-item-favorite:hover {
-    transform: translateY(calc(-50% - 1px));
+.playlist-item-favorite:hover,
+.playlist-items .playlist-item:focus-within .playlist-item-favorite {
+    transform: translateY(-50%) scale(1.05);
     box-shadow: 0 8px 20px rgba(255, 77, 103, 0.35);
     filter: brightness(1.05);
 }
 
-.playlist-item-download:hover {
-    transform: translateY(calc(-50% - 1px));
+.playlist-item-download:hover,
+.playlist-items .playlist-item:focus-within .playlist-item-download {
+    transform: translateY(-50%) scale(1.05);
     box-shadow: 0 8px 18px rgba(46, 204, 113, 0.25);
     filter: brightness(1.05);
 }
 
-.playlist-item-remove:hover {
-    transform: translateY(calc(-50% - 1px));
+.playlist-item-remove:hover,
+.playlist-items .playlist-item:focus-within .playlist-item-remove {
+    transform: translateY(-50%) scale(1.05);
     box-shadow: 0 8px 18px rgba(231, 76, 60, 0.28);
     filter: brightness(1.05);
 }
@@ -1323,10 +1326,10 @@ html.mobile-view .playlist-header .playlist-action-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    border: none;
+    border: 1px solid transparent;
     cursor: pointer;
     opacity: 0;
-    transition: all 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
     color: #ffffff;
 }
 
@@ -1349,20 +1352,40 @@ html.mobile-view .playlist-header .playlist-action-btn {
     opacity: 1;
 }
 
-.favorite-item-action:hover {
+.favorite-item-action:hover,
+.favorites .playlist-items .playlist-item:focus-within .favorite-item-action {
     transform: translateY(-50%) scale(1.05);
+    filter: brightness(1.05);
 }
 
-.favorite-item-action--add:hover {
+.favorite-item-action--add {
+    box-shadow: 0 4px 12px rgba(76, 110, 245, 0.22);
+}
+
+.favorite-item-action--download {
+    box-shadow: 0 4px 10px rgba(46, 204, 113, 0.2);
+}
+
+.favorite-item-action--remove {
+    box-shadow: 0 4px 10px rgba(231, 76, 60, 0.22);
+}
+
+.favorite-item-action--add:hover,
+.favorites .playlist-items .playlist-item:focus-within .favorite-item-action--add {
     background: var(--primary-color-dark);
+    box-shadow: 0 8px 20px rgba(76, 110, 245, 0.28);
 }
 
-.favorite-item-action--download:hover {
+.favorite-item-action--download:hover,
+.favorites .playlist-items .playlist-item:focus-within .favorite-item-action--download {
     background: var(--success-color-hover);
+    box-shadow: 0 8px 18px rgba(46, 204, 113, 0.25);
 }
 
-.favorite-item-action--remove:hover {
+.favorite-item-action--remove:hover,
+.favorites .playlist-items .playlist-item:focus-within .favorite-item-action--remove {
     background: rgba(255, 59, 48, 1);
+    box-shadow: 0 8px 18px rgba(231, 76, 60, 0.28);
 }
 
 html.mobile-view .mobile-panel-header .playlist-tabs {
@@ -1405,12 +1428,26 @@ html.mobile-view .playlist-item-remove {
     right: 12px;
 }
 
+html.mobile-view .playlist-item-favorite:hover,
+html.mobile-view .playlist-items .playlist-item:focus-within .playlist-item-favorite,
+html.mobile-view .playlist-item-download:hover,
+html.mobile-view .playlist-items .playlist-item:focus-within .playlist-item-download,
+html.mobile-view .playlist-item-remove:hover,
+html.mobile-view .playlist-items .playlist-item:focus-within .playlist-item-remove {
+    transform: translateY(-50%);
+    box-shadow: none;
+    filter: none;
+}
+
 html.mobile-view .favorites .favorite-item-action {
     opacity: 1;
 }
 
-html.mobile-view .favorites .favorite-item-action:hover {
+html.mobile-view .favorites .favorite-item-action:hover,
+html.mobile-view .favorites .playlist-items .playlist-item:focus-within .favorite-item-action {
     transform: translateY(-50%);
+    box-shadow: none;
+    filter: none;
 }
 
 html.mobile-view .favorites .playlist-items .playlist-item {

--- a/css/style.css
+++ b/css/style.css
@@ -433,8 +433,11 @@ body.background-transitioning .background-stage__layer--transition {
 
 .import-selected-btn {
     display: inline-flex;
+    flex-direction: row;
     align-items: center;
     gap: 6px;
+    writing-mode: horizontal-tb;
+    white-space: nowrap;
 }
 
 .import-dropdown-caret {
@@ -643,8 +646,11 @@ body.background-transitioning .background-stage__layer--transition {
 
 .import-selected-btn {
     display: inline-flex;
+    flex-direction: row;
     align-items: center;
     gap: 6px;
+    writing-mode: horizontal-tb;
+    white-space: nowrap;
     border: none;
     border-radius: 999px;
     padding: 8px 16px;
@@ -791,21 +797,25 @@ body.background-transitioning .background-stage__layer--transition {
 }
 
 .current-song-title-row {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
+    position: relative;
     width: 100%;
     margin-bottom: 5px;
 }
 
 .current-song-title-row .current-song-title {
-    flex: 0 0 auto;
+    display: block;
+    width: 100%;
     text-align: center;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: calc(100% - 40px);
+}
+
+.current-song-title-row .current-favorite-btn {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .current-song-title {
@@ -959,6 +969,18 @@ body.dark-mode .playlist-action-btn {
 .playlist-action-btn--clear {
     color: rgba(231, 76, 60, 0.85);
     border-color: rgba(231, 76, 60, 0.28);
+}
+
+#clearFavoritesBtn {
+    color: rgba(231, 76, 60, 0.85);
+    border-color: rgba(231, 76, 60, 0.28);
+    background: rgba(255, 59, 48, 0.8);
+}
+
+#clearFavoritesBtn:hover,
+#clearFavoritesBtn:focus-visible {
+    background: rgba(255, 59, 48, 1);
+    color: #fff;
 }
 
 .playlist-action-btn--clear:hover:not(:disabled),
@@ -1207,7 +1229,7 @@ html.mobile-view .playlist-header {
 
 .playlist-item-favorite .fas,
 .playlist-item-favorite .far {
-    transition: transform 0.2s ease, color 0.2s ease;
+    transition: color 0.2s ease;
 }
 
 .playlist-item-favorite.is-active {
@@ -1224,13 +1246,12 @@ html.mobile-view .playlist-header {
     opacity: 1;
 }
 
-.playlist-item-favorite:hover .fas,
-.playlist-item-favorite:hover .far {
-    transform: scale(1.1);
-}
-
 .playlist-item-favorite:hover {
     color: #ffffff;
+}
+
+.playlist-item-favorite.favorite-toggle:hover {
+    transform: translateY(-50%);
 }
 
 .playlist-items .playlist-item:hover .playlist-item-remove {

--- a/css/style.css
+++ b/css/style.css
@@ -449,14 +449,20 @@ body.background-transitioning .background-stage__layer--transition {
     position: absolute;
     top: calc(100% + 4px);
     right: 0;
-    background: var(--component-bg);
+    background: rgba(255, 255, 255, 0.98);
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     padding: 6px 0;
     min-width: 160px;
     z-index: 20000;
     pointer-events: auto;
+}
+
+.dark-mode .import-dropdown-menu {
+    background: rgba(28, 28, 28, 0.98);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
 }
 
 .import-dropdown-menu[hidden] {
@@ -1445,13 +1451,19 @@ html.mobile-view .favorites .favorite-item-action--remove {
 }
 /* 动态质量菜单样式 */
 .dynamic-quality-menu {
-    background: var(--component-bg);
+    background: rgba(255, 255, 255, 0.98);
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.18);
     padding: 8px 0;
     min-width: 150px;
     animation: fadeIn 0.2s ease;
+}
+
+.dark-mode .dynamic-quality-menu {
+    background: rgba(28, 28, 28, 0.98);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.55);
 }
 
 .dynamic-quality-menu .quality-option {
@@ -1722,7 +1734,7 @@ input[type="range"]:active::-moz-range-thumb {
     position: absolute;
     top: calc(100% + 10px);
     right: 0;
-    background: rgba(255, 255, 255, 0.95);
+    background: #ffffff;
     border-radius: 12px;
     box-shadow: 0 12px 30px rgba(0,0,0,0.2);
     border: 1px solid var(--border-color);
@@ -1732,10 +1744,14 @@ input[type="range"]:active::-moz-range-thumb {
     visibility: hidden;
     transform: translateY(-10px);
     transition: all 0.2s ease;
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
     z-index: 100000;
     pointer-events: none;
+}
+
+.dark-mode .player-quality-menu {
+    background: #1c1c1c;
+    border-color: rgba(255, 255, 255, 0.15);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.6);
 }
 
 .player-quality-menu.show {
@@ -1775,6 +1791,7 @@ input[type="range"]:active::-moz-range-thumb {
     color: var(--text-color);
     cursor: pointer;
     transition: all 0.2s ease;
+    background: transparent;
 }
 
 .player-quality-option:hover,
@@ -1834,7 +1851,7 @@ input[type="range"]:active::-moz-range-thumb {
     position: absolute;
     top: 100%;
     right: 0;
-    background: rgba(255, 255, 255, 0.95);
+    background: #ffffff;
     border: 2px solid var(--primary-color);
     border-radius: 8px;
     box-shadow: 0 8px 20px rgba(0,0,0,0.25);
@@ -1844,9 +1861,13 @@ input[type="range"]:active::-moz-range-thumb {
     visibility: hidden;
     transform: translateY(-10px);
     transition: all 0.2s ease;
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
     pointer-events: none;
+}
+
+.dark-mode .quality-menu {
+    background: #1c1c1c;
+    border-color: rgba(26, 188, 156, 0.6);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.6);
 }
 
 /* 确保搜索结果项在质量菜单显示时不会遮挡 */
@@ -1878,7 +1899,7 @@ input[type="range"]:active::-moz-range-thumb {
     font-size: 10px;
     font-weight: 500;
     color: var(--text-color);
-    background: rgba(255, 255, 255, 0.8);
+    background: transparent;
     border-bottom: 1px solid rgba(26, 188, 156, 0.18);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -635,22 +635,19 @@ body.background-transitioning .background-stage__layer--transition {
 }
 
 .search-result-actions .action-btn.favorite {
-    border-color: rgba(26, 188, 156, 0.55);
-    box-shadow: 0 6px 16px rgba(26, 188, 156, 0.25);
-}
-
-.search-result-actions .action-btn.favorite.is-active {
     background: #ff4d67;
+    color: #ffffff;
     border-color: rgba(255, 77, 103, 0.65);
     box-shadow: 0 6px 16px rgba(255, 77, 103, 0.3);
 }
 
-.search-result-actions .action-btn.favorite {
-    color: #ffffff;
+.search-result-actions .action-btn.favorite.is-active {
+    filter: brightness(1.05);
 }
 
 .search-result-actions .action-btn.favorite:hover {
     color: #ffffff;
+    filter: brightness(1.05);
 }
 
 .search-result-actions .action-btn.play {
@@ -1188,12 +1185,13 @@ html.mobile-view .playlist-header {
     z-index: 5;
 }
 
+
 .playlist-item-favorite {
     right: 74px;
-    background: var(--primary-color);
+    background: #ff4d67;
     color: #ffffff;
-    border-color: rgba(26, 188, 156, 0.5);
-    box-shadow: 0 4px 10px rgba(26, 188, 156, 0.18);
+    border-color: rgba(255, 77, 103, 0.6);
+    box-shadow: 0 4px 12px rgba(255, 77, 103, 0.25);
 }
 
 .playlist-item-favorite .fas,
@@ -1203,10 +1201,7 @@ html.mobile-view .playlist-header {
 }
 
 .playlist-item-favorite.is-active {
-    background: #ff4d67;
-    color: #ffffff;
-    border-color: rgba(255, 77, 103, 0.6);
-    box-shadow: 0 4px 12px rgba(255, 77, 103, 0.25);
+    filter: brightness(1.02);
 }
 
 .playlist-item-favorite.is-active .fas,
@@ -1232,7 +1227,7 @@ html.mobile-view .playlist-header {
 
 .playlist-item-favorite:hover {
     transform: translateY(calc(-50% - 1px));
-    box-shadow: 0 8px 18px rgba(26, 188, 156, 0.3);
+    box-shadow: 0 8px 20px rgba(255, 77, 103, 0.35);
     filter: brightness(1.05);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -42,31 +42,6 @@
     --success-color-hover: #1f8a4f;
 }
 
-.dark-mode .quality-menu {
-    background: rgba(44, 44, 44, 0.95);
-    border: 2px solid var(--primary-color);
-}
-
-.dark-mode .quality-option {
-    background: rgba(44, 44, 44, 0.8);
-    color: #ecf0f1;
-    border-bottom: 1px solid rgba(26, 188, 156, 0.25);
-}
-
-.dark-mode .player-quality-menu {
-    background: rgba(44, 44, 44, 0.95);
-    border-color: var(--primary-color);
-}
-
-.dark-mode .player-quality-option {
-    color: #ecf0f1;
-}
-
-.dark-mode .player-quality-option:hover,
-.dark-mode .player-quality-option.active {
-    color: #ffffff;
-}
-
 .dark-mode .source-menu {
     background: rgba(44, 44, 44, 0.95);
     border-color: var(--primary-color);
@@ -1451,37 +1426,20 @@ html.mobile-view .favorites .favorite-item-action--remove {
 }
 /* 动态质量菜单样式 */
 .dynamic-quality-menu {
-    background: rgba(255, 255, 255, 0.98);
+    background: #ffffff;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.18);
-    padding: 8px 0;
-    min-width: 150px;
-    animation: fadeIn 0.2s ease;
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+    padding: 6px 0;
+    min-width: 180px;
+    overflow: hidden;
+    z-index: 100000;
 }
 
 .dark-mode .dynamic-quality-menu {
-    background: rgba(28, 28, 28, 0.98);
-    border-color: rgba(255, 255, 255, 0.12);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.55);
-}
-
-.dynamic-quality-menu .quality-option {
-    padding: 8px 16px;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
-    font-size: 14px;
-    color: var(--text-color);
-}
-
-.dynamic-quality-menu .quality-option:hover {
-    background: var(--primary-color);
-    color: white;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-5px); }
-    to { opacity: 1; transform: translateY(0); }
+    background: #1c1c1c;
+    border-color: rgba(255, 255, 255, 0.15);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.6);
 }
 
 .lyrics {
@@ -1782,10 +1740,12 @@ input[type="range"]:active::-moz-range-thumb {
     transform-origin: top center;
 }
 
-.player-quality-option {
+.player-quality-option,
+.quality-option {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 10px 14px;
     font-size: 0.9em;
     color: var(--text-color);
@@ -1795,12 +1755,15 @@ input[type="range"]:active::-moz-range-thumb {
 }
 
 .player-quality-option:hover,
-.player-quality-option.active {
+.player-quality-option.active,
+.quality-option:hover,
+.quality-option.active {
     background: var(--primary-color);
     color: white;
 }
 
-.player-quality-option small {
+.player-quality-option small,
+.quality-option small {
     opacity: 0.7;
 }
 
@@ -1849,25 +1812,26 @@ input[type="range"]:active::-moz-range-thumb {
 /* 下载质量选择菜单 - 修复层级和显示问题 */
 .quality-menu {
     position: absolute;
-    top: 100%;
+    top: calc(100% + 10px);
     right: 0;
     background: #ffffff;
-    border: 2px solid var(--primary-color);
-    border-radius: 8px;
-    box-shadow: 0 8px 20px rgba(0,0,0,0.25);
-    z-index: 999999;
-    min-width: 120px;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+    z-index: 100000;
+    min-width: 180px;
     opacity: 0;
     visibility: hidden;
     transform: translateY(-10px);
     transition: all 0.2s ease;
     pointer-events: none;
+    overflow: hidden;
 }
 
 .dark-mode .quality-menu {
     background: #1c1c1c;
-    border-color: rgba(26, 188, 156, 0.6);
-    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.6);
+    border-color: rgba(255, 255, 255, 0.15);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.6);
 }
 
 /* 确保搜索结果项在质量菜单显示时不会遮挡 */
@@ -1890,32 +1854,6 @@ input[type="range"]:active::-moz-range-thumb {
     visibility: visible;
     transform: translateY(0);
     pointer-events: auto;
-}
-
-.quality-option {
-    padding: 6px 10px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-size: 10px;
-    font-weight: 500;
-    color: var(--text-color);
-    background: transparent;
-    border-bottom: 1px solid rgba(26, 188, 156, 0.18);
-}
-
-.quality-option:hover {
-    background: var(--primary-color);
-    color: white;
-    transform: translateX(2px);
-}
-
-.quality-option:first-child {
-    border-radius: 6px 6px 0 0;
-}
-
-.quality-option:last-child {
-    border-radius: 0 0 6px 6px;
-    border-bottom: none;
 }
 
 /* 加载更多按钮 - 增强样式 */

--- a/css/style.css
+++ b/css/style.css
@@ -627,14 +627,22 @@ body.background-transitioning .background-stage__layer--transition {
     justify-content: center;
     font-size: 14px;
     gap: 0;
+    border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 .search-result-actions .action-btn i {
     margin: 0;
 }
 
+.search-result-actions .action-btn.favorite {
+    border-color: rgba(26, 188, 156, 0.55);
+    box-shadow: 0 6px 16px rgba(26, 188, 156, 0.25);
+}
+
 .search-result-actions .action-btn.favorite.is-active {
     background: #ff4d67;
+    border-color: rgba(255, 77, 103, 0.65);
+    box-shadow: 0 6px 16px rgba(255, 77, 103, 0.3);
 }
 
 .search-result-actions .action-btn.favorite {
@@ -643,6 +651,15 @@ body.background-transitioning .background-stage__layer--transition {
 
 .search-result-actions .action-btn.favorite:hover {
     color: #ffffff;
+}
+
+.search-result-actions .action-btn.play {
+    border-color: rgba(26, 188, 156, 0.45);
+}
+
+.search-result-actions .action-btn.download {
+    border-color: rgba(46, 204, 113, 0.55);
+    box-shadow: 0 6px 16px rgba(46, 204, 113, 0.28);
 }
 
 
@@ -1127,7 +1144,7 @@ html.mobile-view .playlist-header {
 
 .playlist-items .playlist-item {
     padding: 10px 12px;
-    padding-right: 140px;
+    padding-right: 110px;
     border-radius: 8px;
     transition: all 0.2s ease-in-out;
     cursor: pointer;
@@ -1149,31 +1166,34 @@ html.mobile-view .playlist-header {
     background-color: var(--item-current-bg);
 }
 
+
 .playlist-item-favorite,
 .playlist-item-download,
 .playlist-item-remove {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    width: 32px;
-    height: 32px;
-    border-radius: 8px;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
     display: flex;
     align-items: center;
     justify-content: center;
-    border: none;
+    border: 1px solid transparent;
     padding: 0;
     font-size: 14px;
     cursor: pointer;
-    opacity: 0;
+    opacity: 1;
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
     z-index: 5;
 }
 
 .playlist-item-favorite {
-    right: 104px;
+    right: 74px;
     background: var(--primary-color);
     color: #ffffff;
+    border-color: rgba(26, 188, 156, 0.5);
+    box-shadow: 0 4px 10px rgba(26, 188, 156, 0.18);
 }
 
 .playlist-item-favorite .fas,
@@ -1185,6 +1205,8 @@ html.mobile-view .playlist-header {
 .playlist-item-favorite.is-active {
     background: #ff4d67;
     color: #ffffff;
+    border-color: rgba(255, 77, 103, 0.6);
+    box-shadow: 0 4px 12px rgba(255, 77, 103, 0.25);
 }
 
 .playlist-item-favorite.is-active .fas,
@@ -1193,26 +1215,24 @@ html.mobile-view .playlist-header {
 }
 
 .playlist-item-download {
-    right: 56px;
+    right: 42px;
     background: var(--success-color);
     color: #ffffff;
+    border-color: rgba(46, 204, 113, 0.5);
+    box-shadow: 0 4px 10px rgba(46, 204, 113, 0.2);
 }
 
 .playlist-item-remove {
-    right: 8px;
+    right: 10px;
     background: rgba(255, 59, 48, 0.9);
     color: #ffffff;
-}
-
-.playlist-items .playlist-item:hover .playlist-item-favorite,
-.playlist-items .playlist-item:hover .playlist-item-download,
-.playlist-items .playlist-item:hover .playlist-item-remove {
-    opacity: 1;
+    border-color: rgba(231, 76, 60, 0.5);
+    box-shadow: 0 4px 10px rgba(231, 76, 60, 0.22);
 }
 
 .playlist-item-favorite:hover {
     transform: translateY(calc(-50% - 1px));
-    box-shadow: 0 8px 18px rgba(26, 188, 156, 0.25);
+    box-shadow: 0 8px 18px rgba(26, 188, 156, 0.3);
     filter: brightness(1.05);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1264,15 +1264,22 @@ html.mobile-view .playlist-header {
 }
 
 .playlist-item-favorite.favorite-toggle {
+    padding: 0;
+    background: #ff4d67;
     color: #ffffff;
+    border: 1px solid rgba(255, 77, 103, 0.6);
+    box-shadow: 0 4px 12px rgba(255, 77, 103, 0.25);
 }
 
 .playlist-item-favorite.favorite-toggle:hover {
     color: #ffffff;
+    background: #e6435b;
+    box-shadow: 0 8px 20px rgba(255, 77, 103, 0.35);
 }
 
 .playlist-item-favorite.favorite-toggle.is-active {
     color: #ffffff;
+    filter: brightness(1.03);
 }
 
 .current-favorite-btn {

--- a/css/style.css
+++ b/css/style.css
@@ -709,7 +709,7 @@ body.background-transitioning .background-stage__layer--transition {
     text-align: center;
     box-sizing: border-box;
     height: 100%;
-    overflow-y: auto;
+    overflow: hidden;
     transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -756,11 +756,24 @@ body.background-transitioning .background-stage__layer--transition {
     width: 100%;
 }
 
+.current-song-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 5px;
+}
+
+.current-song-title-row .current-song-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .current-song-title {
     font-size: 16px;
     font-weight: 600;
     color: var(--text-color);
-    margin-bottom: 5px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -809,6 +822,11 @@ body.background-transitioning .background-stage__layer--transition {
 
 html.desktop-view .playlist {
     padding-top: 72px;
+}
+
+.playlist[hidden],
+.playlist.favorites[hidden] {
+    display: none !important;
 }
 
 
@@ -945,6 +963,10 @@ html.mobile-view .playlist-header {
     font-style: italic;
     opacity: 0.7;
     font-size: 0.9em;
+}
+
+.playlist.favorites.empty::before {
+    content: "";
 }
 
 .playlist-scroll {
@@ -1188,13 +1210,6 @@ html.mobile-view .playlist-header {
 
 .favorite-toggle.is-active {
     color: #ff4d67;
-}
-
-.current-song-actions {
-    display: flex;
-    align-items: center;
-    margin: 6px 0;
-    gap: 8px;
 }
 
 .current-favorite-btn {

--- a/css/style.css
+++ b/css/style.css
@@ -1028,8 +1028,15 @@ html.mobile-view .playlist-header {
     color: var(--primary-color);
 }
 
-.favorites {
-    margin-top: 16px;
+/* 使收藏列表与播放列表共享相同的定位和内边距 */
+.playlist.favorites {
+    margin-top: 0;
+    padding-top: 72px;
+}
+
+/* 切换时隐藏非激活列表的标题和操作按钮 */
+.playlist:not(.active) .playlist-header {
+    display: none;
 }
 
 .favorites[hidden] {

--- a/css/style.css
+++ b/css/style.css
@@ -807,6 +807,10 @@ body.background-transitioning .background-stage__layer--transition {
     box-sizing: border-box;
 }
 
+html.desktop-view .playlist {
+    padding-top: 72px;
+}
+
 
 .playlist-header {
     position: absolute;
@@ -821,26 +825,16 @@ body.background-transitioning .background-stage__layer--transition {
     z-index: 5;
 }
 
-.playlist-label {
+.playlist-header > * {
+    pointer-events: auto;
+}
+
+.playlist-header .playlist-tabs {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    color: var(--text-secondary-color);
-    font-size: 15px;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    line-height: 1.2;
-    pointer-events: none;
-    text-transform: none;
-    white-space: nowrap;
-}
-
-html.desktop-view body.dark-mode .playlist-label {
-    color: var(--text-color);
-}
-
-html.mobile-view .playlist-label {
-    display: none;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
 }
 
 .playlist-actions-tray {
@@ -969,12 +963,50 @@ html.mobile-view .playlist-header {
 .playlist-tabs {
     display: flex;
     gap: 8px;
-    margin-bottom: 12px;
 }
 
 .playlist-tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-secondary-color);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
+.playlist-tab:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.playlist-tab:hover:not(.active) {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+.playlist-tab.active {
+    background: var(--primary-color);
+    color: #fff;
+    border-color: var(--primary-color);
+}
+
+.mobile-panel-header .playlist-tabs {
+    display: flex;
+    gap: 6px;
     flex: 1;
-    padding: 10px 12px;
+}
+
+.mobile-panel-header .playlist-tab {
+    flex: 1;
+    padding: 8px 12px;
     border-radius: 12px;
     border: 1px solid var(--border-color);
     background: transparent;
@@ -985,15 +1017,15 @@ html.mobile-view .playlist-header {
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.playlist-tab:hover {
-    border-color: var(--accent-color);
-    color: var(--text-primary-color);
+.mobile-panel-header .playlist-tab.active {
+    background: var(--primary-color);
+    color: #fff;
+    border-color: var(--primary-color);
 }
 
-.playlist-tab.active {
-    background: var(--accent-color);
-    color: #fff;
-    border-color: var(--accent-color);
+.mobile-panel-header .playlist-tab:hover:not(.active) {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
 }
 
 .favorites {

--- a/css/style.css
+++ b/css/style.css
@@ -1295,6 +1295,8 @@ html.mobile-view .playlist-header .playlist-action-btn {
     color: #ffffff;
     border: 1px solid rgba(255, 77, 103, 0.6);
     box-shadow: 0 4px 12px rgba(255, 77, 103, 0.25);
+    transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+        filter 0.2s ease, color 0.2s ease;
 }
 
 .playlist-item-favorite.favorite-toggle:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -1194,9 +1194,18 @@ html.mobile-view .playlist-header .playlist-action-btn {
     padding: 0;
     font-size: 14px;
     cursor: pointer;
-    opacity: 1;
+    opacity: 0;
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
     z-index: 5;
+}
+
+.playlist-items .playlist-item:hover .playlist-item-favorite,
+.playlist-items .playlist-item:hover .playlist-item-download,
+.playlist-items .playlist-item:hover .playlist-item-remove,
+.playlist-items .playlist-item:focus-within .playlist-item-favorite,
+.playlist-items .playlist-item:focus-within .playlist-item-download,
+.playlist-items .playlist-item:focus-within .playlist-item-remove {
+    opacity: 1;
 }
 
 
@@ -1381,6 +1390,7 @@ html.mobile-view .playlist-item-remove {
     width: 28px;
     height: 28px;
     border-radius: 8px;
+    opacity: 1;
 }
 
 html.mobile-view .playlist-item-favorite {

--- a/css/style.css
+++ b/css/style.css
@@ -11,6 +11,7 @@
     --primary-color-dark: #12836d;
     --warning-color: #e74c3c;
     --success-color: #2ecc71;
+    --success-color-hover: #27ae60;
     --item-hover-bg: rgba(26, 188, 156, 0.1);
     --item-current-bg: rgba(26, 188, 156, 0.2);
     --item-current-text: var(--primary-color);
@@ -38,6 +39,7 @@
     --lyrics-highlight-text: #34d1b6;
     --component-bg: rgba(44, 44, 44, 0.5);
     --scrollbar-thumb-bg: rgba(255, 255, 255, 0.2);
+    --success-color-hover: #1f8a4f;
 }
 
 .dark-mode .quality-menu {
@@ -612,6 +614,33 @@ body.background-transitioning .background-stage__layer--transition {
     margin-left: 15px;
 }
 
+.search-result-actions .action-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 8px;
+    justify-content: center;
+    font-size: 14px;
+    gap: 0;
+}
+
+.search-result-actions .action-btn i {
+    margin: 0;
+}
+
+.search-result-actions .action-btn.favorite.is-active {
+    background: #ff4d67;
+}
+
+.search-result-actions .action-btn.favorite {
+    color: #ffffff;
+}
+
+.search-result-actions .action-btn.favorite:hover {
+    color: #ffffff;
+}
+
+
 .import-selected-btn {
     display: inline-flex;
     align-items: center;
@@ -682,6 +711,11 @@ body.background-transitioning .background-stage__layer--transition {
 .action-btn.download:hover {
     background: #27ae60;
     box-shadow: 0 4px 12px rgba(46, 204, 113, 0.3);
+}
+
+.search-result-actions .action-btn.download {
+    padding: 0;
+    font-size: 14px;
 }
 
 /* 主要内容区域 - 播放模式显示，搜索模式隐藏 */
@@ -758,13 +792,16 @@ body.background-transitioning .background-stage__layer--transition {
 
 .current-song-title-row {
     display: flex;
+    justify-content: center;
     align-items: center;
     gap: 8px;
+    width: 100%;
     margin-bottom: 5px;
 }
 
 .current-song-title-row .current-song-title {
-    flex: 1;
+    flex: 1 1 auto;
+    text-align: center;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -1095,7 +1132,7 @@ html.mobile-view .playlist-header {
 /* 播放列表项下载按钮 - 修复大小和显示问题 */
 .playlist-item-download {
     position: absolute;
-    right: 62px; /* Adjusted position to accommodate favorite按钮 */
+    right: 35px;
     top: 50%;
     transform: translateY(-50%);
     background: var(--success-color);
@@ -1149,12 +1186,12 @@ html.mobile-view .playlist-header {
 
 .playlist-item-favorite {
     position: absolute;
-    right: 35px;
+    right: 62px;
     top: 50%;
     transform: translateY(-50%);
-    background: transparent;
+    background: var(--primary-color);
     border: none;
-    color: var(--text-secondary-color);
+    color: #ffffff;
     cursor: pointer;
     opacity: 0;
     transition: all 0.2s ease;
@@ -1164,22 +1201,35 @@ html.mobile-view .playlist-header {
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: 4px;
 }
 
-.playlist-item-favorite .fas {
+.playlist-item-favorite .fas,
+.playlist-item-favorite .far {
     transition: transform 0.2s ease, color 0.2s ease;
 }
 
-.playlist-item-favorite.is-active .fas {
-    color: #ff4d67;
+.playlist-item-favorite.is-active {
+    background: #ff4d67;
+    color: #ffffff;
+}
+
+.playlist-item-favorite.is-active .fas,
+.playlist-item-favorite.is-active .far {
+    color: #ffffff;
 }
 
 .playlist-items .playlist-item:hover .playlist-item-favorite {
     opacity: 1;
 }
 
-.playlist-item-favorite:hover .fas {
+.playlist-item-favorite:hover .fas,
+.playlist-item-favorite:hover .far {
     transform: scale(1.1);
+}
+
+.playlist-item-favorite:hover {
+    color: #ffffff;
 }
 
 .playlist-items .playlist-item:hover .playlist-item-remove {

--- a/css/style.css
+++ b/css/style.css
@@ -429,6 +429,7 @@ body.background-transitioning .background-stage__layer--transition {
     position: relative;
     display: inline-flex;
     align-items: stretch;
+    z-index: 20000;
 }
 
 .import-selected-btn {
@@ -454,7 +455,8 @@ body.background-transitioning .background-stage__layer--transition {
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
     padding: 6px 0;
     min-width: 160px;
-    z-index: 1000;
+    z-index: 20000;
+    pointer-events: auto;
 }
 
 .import-dropdown-menu[hidden] {
@@ -797,14 +799,18 @@ body.background-transitioning .background-stage__layer--transition {
 }
 
 .current-song-title-row {
-    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
     width: 100%;
     margin-bottom: 5px;
 }
 
 .current-song-title-row .current-song-title {
-    display: block;
-    width: 100%;
+    flex: 0 1 auto;
+    max-width: calc(100% - 40px);
+    min-width: 0;
     text-align: center;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -812,10 +818,12 @@ body.background-transitioning .background-stage__layer--transition {
 }
 
 .current-song-title-row .current-favorite-btn {
-    position: absolute;
-    right: 0;
-    top: 50%;
-    transform: translateY(-50%);
+    position: static;
+    transform: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
 }
 
 .current-song-title {
@@ -971,18 +979,6 @@ body.dark-mode .playlist-action-btn {
     border-color: rgba(231, 76, 60, 0.28);
 }
 
-#clearFavoritesBtn {
-    color: rgba(231, 76, 60, 0.85);
-    border-color: rgba(231, 76, 60, 0.28);
-    background: rgba(255, 59, 48, 0.8);
-}
-
-#clearFavoritesBtn:hover,
-#clearFavoritesBtn:focus-visible {
-    background: rgba(255, 59, 48, 1);
-    color: #fff;
-}
-
 .playlist-action-btn--clear:hover:not(:disabled),
 .playlist-action-btn--clear:focus-visible:not(:disabled) {
     filter: brightness(1.05);
@@ -1131,6 +1127,7 @@ html.mobile-view .playlist-header {
 
 .playlist-items .playlist-item {
     padding: 10px 12px;
+    padding-right: 140px;
     border-radius: 8px;
     transition: all 0.2s ease-in-out;
     cursor: pointer;
@@ -1152,83 +1149,36 @@ html.mobile-view .playlist-header {
     background-color: var(--item-current-bg);
 }
 
-/* 播放列表项下载按钮 - 修复大小和显示问题 */
-.playlist-item-download {
-    position: absolute;
-    right: 35px;
-    top: 50%;
-    transform: translateY(-50%);
-    background: var(--success-color);
-    color: white;
-    border: none;
-    border-radius: 4px;
-    padding: 4px;
-    font-size: 10px;
-    cursor: pointer;
-    opacity: 0;
-    transition: all 0.2s ease;
-    z-index: 1000;
-    width: 20px;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.playlist-items .playlist-item:hover .playlist-item-download {
-    opacity: 1;
-}
-
-.playlist-item-download:hover {
-    background: var(--success-color-hover);
-    transform: translateY(-50%) scale(1.05);
-}
-
-/* 播放列表项删除按钮 */
+.playlist-item-favorite,
+.playlist-item-download,
 .playlist-item-remove {
     position: absolute;
-    right: 8px; /* Adjusted position */
     top: 50%;
     transform: translateY(-50%);
-    background: rgba(255, 59, 48, 0.8);
-    color: white;
-    border: none;
-    border-radius: 4px;
-    padding: 4px;
-    font-size: 10px;
-    cursor: pointer;
-    opacity: 0;
-    transition: all 0.2s ease;
-    z-index: 1000;
-    width: 20px;
-    height: 20px;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
+    border: none;
+    padding: 0;
+    font-size: 14px;
+    cursor: pointer;
+    opacity: 0;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
+    z-index: 5;
 }
 
 .playlist-item-favorite {
-    position: absolute;
-    right: 62px;
-    top: 50%;
-    transform: translateY(-50%);
+    right: 104px;
     background: var(--primary-color);
-    border: none;
     color: #ffffff;
-    cursor: pointer;
-    opacity: 0;
-    transition: all 0.2s ease;
-    z-index: 1000;
-    width: 20px;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
 }
 
 .playlist-item-favorite .fas,
 .playlist-item-favorite .far {
+    margin: 0;
     transition: color 0.2s ease;
 }
 
@@ -1242,46 +1192,72 @@ html.mobile-view .playlist-header {
     color: #ffffff;
 }
 
-.playlist-items .playlist-item:hover .playlist-item-favorite {
-    opacity: 1;
-}
-
-.playlist-item-favorite:hover {
+.playlist-item-download {
+    right: 56px;
+    background: var(--success-color);
     color: #ffffff;
 }
 
-.playlist-item-favorite.favorite-toggle:hover {
-    transform: translateY(-50%);
+.playlist-item-remove {
+    right: 8px;
+    background: rgba(255, 59, 48, 0.9);
+    color: #ffffff;
 }
 
+.playlist-items .playlist-item:hover .playlist-item-favorite,
+.playlist-items .playlist-item:hover .playlist-item-download,
 .playlist-items .playlist-item:hover .playlist-item-remove {
     opacity: 1;
 }
 
+.playlist-item-favorite:hover {
+    transform: translateY(calc(-50% - 1px));
+    box-shadow: 0 8px 18px rgba(26, 188, 156, 0.25);
+    filter: brightness(1.05);
+}
+
+.playlist-item-download:hover {
+    transform: translateY(calc(-50% - 1px));
+    box-shadow: 0 8px 18px rgba(46, 204, 113, 0.25);
+    filter: brightness(1.05);
+}
+
 .playlist-item-remove:hover {
-    background: rgba(255, 59, 48, 1);
-    transform: translateY(-50%) scale(1.05);
+    transform: translateY(calc(-50% - 1px));
+    box-shadow: 0 8px 18px rgba(231, 76, 60, 0.28);
+    filter: brightness(1.05);
 }
 
 .favorite-toggle {
     border: none;
-    background: transparent;
+    background: none;
     color: var(--text-secondary-color);
     cursor: pointer;
     padding: 4px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    transition: color 0.2s ease, transform 0.2s ease;
+    transition: color 0.2s ease;
 }
 
 .favorite-toggle:hover {
-    color: var(--accent-color);
-    transform: scale(1.05);
+    color: var(--primary-color);
 }
 
 .favorite-toggle.is-active {
     color: #ff4d67;
+}
+
+.playlist-item-favorite.favorite-toggle {
+    color: #ffffff;
+}
+
+.playlist-item-favorite.favorite-toggle:hover {
+    color: #ffffff;
+}
+
+.playlist-item-favorite.favorite-toggle.is-active {
+    color: #ffffff;
 }
 
 .current-favorite-btn {
@@ -1289,7 +1265,7 @@ html.mobile-view .playlist-header {
 }
 
 .favorites .playlist-items .playlist-item {
-    padding-right: 110px;
+    padding-right: 150px;
 }
 
 .favorite-item-action {

--- a/css/style.css
+++ b/css/style.css
@@ -413,7 +413,7 @@ body.background-transitioning .background-stage__layer--transition {
 }
 
 .search-results-toolbar {
-    display: flex;
+    display: flex !important;
     justify-content: flex-end;
     align-items: center;
     gap: 8px;
@@ -800,11 +800,12 @@ body.background-transitioning .background-stage__layer--transition {
 }
 
 .current-song-title-row .current-song-title {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     text-align: center;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: calc(100% - 40px);
 }
 
 .current-song-title {
@@ -1274,32 +1275,32 @@ html.mobile-view .playlist-header {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    background: var(--component-bg);
-    border: none;
-    color: var(--text-secondary-color);
-    width: 24px;
-    height: 24px;
-    border-radius: 6px;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
     display: flex;
     align-items: center;
     justify-content: center;
+    border: none;
     cursor: pointer;
     opacity: 0;
     transition: all 0.2s ease;
+    color: #ffffff;
 }
 
 .favorite-item-action--add {
     right: 74px;
+    background: var(--primary-color);
 }
 
 .favorite-item-action--download {
     right: 42px;
+    background: var(--success-color);
 }
 
 .favorite-item-action--remove {
     right: 10px;
     background: rgba(255, 59, 48, 0.8);
-    color: #fff;
 }
 
 .favorites .playlist-item:hover .favorite-item-action {
@@ -1308,7 +1309,14 @@ html.mobile-view .playlist-header {
 
 .favorite-item-action:hover {
     transform: translateY(-50%) scale(1.05);
-    color: var(--text-primary-color);
+}
+
+.favorite-item-action--add:hover {
+    background: var(--primary-color-dark);
+}
+
+.favorite-item-action--download:hover {
+    background: var(--success-color-hover);
 }
 
 .favorite-item-action--remove:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -1125,12 +1125,14 @@ html.mobile-view .playlist-header .playlist-action-btn {
     display: flex;
     gap: 4px;
     justify-self: flex-start;
+    flex: 0 0 auto;
 }
 
 .mobile-panel-header .playlist-tab {
     flex: 0 0 auto;
-    padding: 4px 8px;
-    border-radius: 10px;
+    height: 36px;
+    padding: 0 12px;
+    border-radius: 999px;
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--text-secondary-color);
@@ -1375,15 +1377,15 @@ html.mobile-view .playlist-header .playlist-action-btn {
 
 html.mobile-view .mobile-panel-header .playlist-tabs {
     gap: 6px;
-    justify-self: stretch;
-    max-width: 100%;
+    justify-self: flex-start;
+    flex: 0 0 auto;
 }
 
 html.mobile-view .mobile-panel-header .playlist-tab {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     min-width: 0;
     height: 38px;
-    padding: 0 16px;
+    padding: 0 14px;
     border-radius: 999px;
     font-size: 13px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -423,6 +423,55 @@ body.background-transitioning .background-stage__layer--transition {
     background: none;
 }
 
+.import-dropdown {
+    position: relative;
+    display: inline-flex;
+    align-items: stretch;
+}
+
+.import-selected-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.import-dropdown-caret {
+    font-size: 12px;
+}
+
+.import-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    background: var(--component-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    padding: 6px 0;
+    min-width: 160px;
+    z-index: 1000;
+}
+
+.import-dropdown-menu[hidden] {
+    display: none;
+}
+
+.import-dropdown-item {
+    width: 100%;
+    padding: 8px 14px;
+    background: transparent;
+    border: none;
+    text-align: left;
+    font-size: 14px;
+    color: var(--text-primary-color);
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.import-dropdown-item:hover {
+    background: var(--item-hover-bg);
+}
+
 .search-results-list {
     display: flex;
     flex-direction: column;
@@ -917,6 +966,44 @@ html.mobile-view .playlist-header {
     display: none;
 }
 
+.playlist-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.playlist-tab {
+    flex: 1;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-secondary-color);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.playlist-tab:hover {
+    border-color: var(--accent-color);
+    color: var(--text-primary-color);
+}
+
+.playlist-tab.active {
+    background: var(--accent-color);
+    color: #fff;
+    border-color: var(--accent-color);
+}
+
+.favorites {
+    margin-top: 16px;
+}
+
+.favorites[hidden] {
+    display: none !important;
+}
+
 .playlist-items {
     width: 100%;
 }
@@ -947,7 +1034,7 @@ html.mobile-view .playlist-header {
 /* 播放列表项下载按钮 - 修复大小和显示问题 */
 .playlist-item-download {
     position: absolute;
-    right: 35px; /* Adjusted position */
+    right: 62px; /* Adjusted position to accommodate favorite按钮 */
     top: 50%;
     transform: translateY(-50%);
     background: var(--success-color);
@@ -999,6 +1086,41 @@ html.mobile-view .playlist-header {
     justify-content: center;
 }
 
+.playlist-item-favorite {
+    position: absolute;
+    right: 35px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    color: var(--text-secondary-color);
+    cursor: pointer;
+    opacity: 0;
+    transition: all 0.2s ease;
+    z-index: 1000;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.playlist-item-favorite .fas {
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.playlist-item-favorite.is-active .fas {
+    color: #ff4d67;
+}
+
+.playlist-items .playlist-item:hover .playlist-item-favorite {
+    opacity: 1;
+}
+
+.playlist-item-favorite:hover .fas {
+    transform: scale(1.1);
+}
+
 .playlist-items .playlist-item:hover .playlist-item-remove {
     opacity: 1;
 }
@@ -1006,6 +1128,87 @@ html.mobile-view .playlist-header {
 .playlist-item-remove:hover {
     background: rgba(255, 59, 48, 1);
     transform: translateY(-50%) scale(1.05);
+}
+
+.favorite-toggle {
+    border: none;
+    background: transparent;
+    color: var(--text-secondary-color);
+    cursor: pointer;
+    padding: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.favorite-toggle:hover {
+    color: var(--accent-color);
+    transform: scale(1.05);
+}
+
+.favorite-toggle.is-active {
+    color: #ff4d67;
+}
+
+.current-song-actions {
+    display: flex;
+    align-items: center;
+    margin: 6px 0;
+    gap: 8px;
+}
+
+.current-favorite-btn {
+    font-size: 18px;
+}
+
+.favorites .playlist-items .playlist-item {
+    padding-right: 110px;
+}
+
+.favorite-item-action {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--component-bg);
+    border: none;
+    color: var(--text-secondary-color);
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0;
+    transition: all 0.2s ease;
+}
+
+.favorite-item-action--add {
+    right: 74px;
+}
+
+.favorite-item-action--download {
+    right: 42px;
+}
+
+.favorite-item-action--remove {
+    right: 10px;
+    background: rgba(255, 59, 48, 0.8);
+    color: #fff;
+}
+
+.favorites .playlist-item:hover .favorite-item-action {
+    opacity: 1;
+}
+
+.favorite-item-action:hover {
+    transform: translateY(-50%) scale(1.05);
+    color: var(--text-primary-color);
+}
+
+.favorite-item-action--remove:hover {
+    background: rgba(255, 59, 48, 1);
 }
 /* 动态质量菜单样式 */
 .dynamic-quality-menu {

--- a/css/style.css
+++ b/css/style.css
@@ -1378,7 +1378,7 @@ html.mobile-view .mobile-panel-header .playlist-tabs {
 }
 
 html.mobile-view .mobile-panel-header .playlist-tab {
-    padding: 5px 8px;
+    padding: 6px 12px;
     font-size: 12px;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1374,12 +1374,18 @@ html.mobile-view .playlist-header .playlist-action-btn {
 }
 
 html.mobile-view .mobile-panel-header .playlist-tabs {
-    gap: 2px;
+    gap: 6px;
+    justify-self: stretch;
+    max-width: 100%;
 }
 
 html.mobile-view .mobile-panel-header .playlist-tab {
-    padding: 6px 12px;
-    font-size: 12px;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 38px;
+    padding: 0 16px;
+    border-radius: 999px;
+    font-size: 13px;
 }
 
 html.mobile-view .playlist-items .playlist-item {

--- a/css/style.css
+++ b/css/style.css
@@ -1092,18 +1092,18 @@ html.mobile-view .playlist-header {
 
 .mobile-panel-header .playlist-tabs {
     display: flex;
-    gap: 6px;
+    gap: 4px;
     flex: 1;
 }
 
 .mobile-panel-header .playlist-tab {
     flex: 1;
-    padding: 8px 12px;
-    border-radius: 12px;
+    padding: 6px 10px;
+    border-radius: 10px;
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--text-secondary-color);
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 500;
     cursor: pointer;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
@@ -1340,6 +1340,67 @@ html.mobile-view .playlist-header {
 
 .favorite-item-action--remove:hover {
     background: rgba(255, 59, 48, 1);
+}
+
+html.mobile-view .mobile-panel-header .playlist-tabs {
+    gap: 2px;
+}
+
+html.mobile-view .mobile-panel-header .playlist-tab {
+    padding: 5px 8px;
+    font-size: 12px;
+}
+
+html.mobile-view .playlist-items .playlist-item {
+    padding-right: 100px;
+}
+
+html.mobile-view .playlist-item-favorite,
+html.mobile-view .playlist-item-download,
+html.mobile-view .playlist-item-remove {
+    width: 18px;
+    height: 18px;
+}
+
+html.mobile-view .playlist-item-favorite {
+    right: 60px;
+}
+
+html.mobile-view .playlist-item-download {
+    right: 34px;
+}
+
+html.mobile-view .playlist-item-remove {
+    right: 8px;
+}
+
+html.mobile-view .favorites .favorite-item-action {
+    opacity: 1;
+}
+
+html.mobile-view .favorites .favorite-item-action:hover {
+    transform: translateY(-50%);
+}
+
+html.mobile-view .favorites .playlist-items .playlist-item {
+    padding-right: 100px;
+}
+
+html.mobile-view .favorites .favorite-item-action {
+    width: 18px;
+    height: 18px;
+}
+
+html.mobile-view .favorites .favorite-item-action--add {
+    right: 60px;
+}
+
+html.mobile-view .favorites .favorite-item-action--download {
+    right: 34px;
+}
+
+html.mobile-view .favorites .favorite-item-action--remove {
+    right: 8px;
 }
 /* 动态质量菜单样式 */
 .dynamic-quality-menu {

--- a/css/style.css
+++ b/css/style.css
@@ -1032,6 +1032,9 @@ html.mobile-view .playlist-header {
 html.mobile-view #playlist.playlist .playlist-header {
     display: none;
 }
+html.mobile-view #favorites.playlist .playlist-header {
+    display: none;
+}
 
 html.mobile-view .playlist-header .playlist-tabs {
     display: none;
@@ -1121,17 +1124,17 @@ html.mobile-view .playlist-header .playlist-action-btn {
 .mobile-panel-header .playlist-tabs {
     display: flex;
     gap: 4px;
-    flex: 1;
+    justify-self: flex-start;
 }
 
 .mobile-panel-header .playlist-tab {
-    flex: 1;
-    padding: 6px 10px;
+    flex: 0 0 auto;
+    padding: 4px 8px;
     border-radius: 10px;
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--text-secondary-color);
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 500;
     cursor: pointer;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;

--- a/css/style.css
+++ b/css/style.css
@@ -1547,11 +1547,25 @@ html.mobile-view .favorites .favorite-item-action--remove {
     transform: translateY(0); 
     box-shadow: 0 2px 5px rgba(0,0,0,0.1); 
 }
-.controls button#loadOnlineBtn { 
-    width: auto; 
-    border-radius: 25px; 
-    padding: 0 25px; 
-    gap: 10px; 
+.controls button#loadOnlineBtn {
+    width: auto;
+    border-radius: 25px;
+    padding: 0 25px;
+    gap: 10px;
+}
+.controls button#loadOnlineBtn .btn-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    line-height: 1;
+}
+.controls button#loadOnlineBtn .btn-text i {
+    line-height: 1;
+}
+.controls button#loadOnlineBtn .loader {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 .controls button:disabled { 
     background: var(--text-secondary-color); 

--- a/css/style.css
+++ b/css/style.css
@@ -1017,7 +1017,35 @@ body.dark-mode .playlist-action-btn {
 }
 
 html.mobile-view .playlist-header {
+    position: static;
+    top: auto;
+    left: auto;
+    right: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    margin-bottom: 12px;
+    pointer-events: auto;
+}
+
+html.mobile-view #playlist.playlist .playlist-header {
     display: none;
+}
+
+html.mobile-view .playlist-header .playlist-tabs {
+    display: none;
+}
+
+html.mobile-view .playlist-header .playlist-actions-tray {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+html.mobile-view .playlist-header .playlist-action-btn {
+    width: 36px;
+    height: 36px;
 }
 
 /* 当播放列表有内容时，调整布局 */
@@ -1352,26 +1380,27 @@ html.mobile-view .mobile-panel-header .playlist-tab {
 }
 
 html.mobile-view .playlist-items .playlist-item {
-    padding-right: 100px;
+    padding-right: 108px;
 }
 
 html.mobile-view .playlist-item-favorite,
 html.mobile-view .playlist-item-download,
 html.mobile-view .playlist-item-remove {
-    width: 18px;
-    height: 18px;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
 }
 
 html.mobile-view .playlist-item-favorite {
-    right: 60px;
+    right: 88px;
 }
 
 html.mobile-view .playlist-item-download {
-    right: 34px;
+    right: 48px;
 }
 
 html.mobile-view .playlist-item-remove {
-    right: 8px;
+    right: 12px;
 }
 
 html.mobile-view .favorites .favorite-item-action {
@@ -1383,24 +1412,25 @@ html.mobile-view .favorites .favorite-item-action:hover {
 }
 
 html.mobile-view .favorites .playlist-items .playlist-item {
-    padding-right: 100px;
+    padding-right: 108px;
 }
 
 html.mobile-view .favorites .favorite-item-action {
-    width: 18px;
-    height: 18px;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
 }
 
 html.mobile-view .favorites .favorite-item-action--add {
-    right: 60px;
+    right: 88px;
 }
 
 html.mobile-view .favorites .favorite-item-action--download {
-    right: 34px;
+    right: 48px;
 }
 
 html.mobile-view .favorites .favorite-item-action--remove {
-    right: 8px;
+    right: 12px;
 }
 /* 动态质量菜单样式 */
 .dynamic-quality-menu {

--- a/index.html
+++ b/index.html
@@ -219,7 +219,28 @@
             <div class="mobile-panel" id="mobilePanel">
                 <div class="mobile-panel-header" id="mobilePanelHeader">
                     <div class="mobile-panel-handle" aria-hidden="true"></div>
-                    <div class="mobile-panel-title" id="mobilePanelTitle">播放列表</div>
+                    <div class="playlist-tabs" role="tablist">
+                        <button
+                            id="mobilePlaylistTab"
+                            class="playlist-tab active"
+                            type="button"
+                            role="tab"
+                            aria-selected="true"
+                            data-target="playlist"
+                        >
+                            播放列表
+                        </button>
+                        <button
+                            id="mobileFavoritesTab"
+                            class="playlist-tab"
+                            type="button"
+                            role="tab"
+                            aria-selected="false"
+                            data-target="favorites"
+                        >
+                            收藏列表
+                        </button>
+                    </div>
                     <div class="mobile-panel-actions">
                         <button
                             id="mobileImportPlaylistBtn"
@@ -259,32 +280,26 @@
                     </div>
                 </div>
 
-                <div class="playlist-tabs" role="tablist">
-                    <button
-                        id="playlistTab"
-                        class="playlist-tab active"
-                        type="button"
-                        role="tab"
-                        aria-selected="true"
-                        data-target="playlist"
-                    >
-                        播放列表
-                    </button>
-                    <button
-                        id="favoritesTab"
-                        class="playlist-tab"
-                        type="button"
-                        role="tab"
-                        aria-selected="false"
-                        data-target="favorites"
-                    >
-                        收藏列表
-                    </button>
-                </div>
-
                 <div class="playlist active empty" id="playlist" role="tabpanel" aria-labelledby="playlistTab">
                     <div class="playlist-header">
-                        <div class="playlist-label" aria-hidden="true">播放列表</div>
+                        <div class="playlist-tabs" role="tablist">
+                            <button
+                                id="playlistTab"
+                                class="playlist-tab active"
+                                type="button"
+                                role="tab"
+                                aria-selected="true"
+                                data-target="playlist"
+                            >播放列表</button>
+                            <button
+                                id="favoritesTab"
+                                class="playlist-tab"
+                                type="button"
+                                role="tab"
+                                aria-selected="false"
+                                data-target="favorites"
+                            >收藏列表</button>
+                        </div>
                         <div class="playlist-actions-tray" role="group" aria-label="播放列表操作">
                             <input
                                 id="importPlaylistInput"
@@ -329,7 +344,6 @@
                 </div>
                 <div class="favorites empty" id="favorites" role="tabpanel" aria-labelledby="favoritesTab" hidden>
                     <div class="playlist-header">
-                        <div class="playlist-label" aria-hidden="true">收藏列表</div>
                         <div class="playlist-actions-tray" role="group" aria-label="收藏列表操作">
                             <button
                                 class="playlist-action-btn"

--- a/index.html
+++ b/index.html
@@ -196,9 +196,8 @@
                     </div>
                 </div>
                 <div class="current-song-info">
-                    <div class="current-song-title" id="currentSongTitle">选择一首歌曲开始播放</div>
-                    <div class="current-song-artist" id="currentSongArtist">未知艺术家</div>
-                    <div class="current-song-actions">
+                    <div class="current-song-title-row">
+                        <span class="current-song-title" id="currentSongTitle">选择一首歌曲开始播放</span>
                         <button
                             class="favorite-toggle current-favorite-btn"
                             id="currentFavoriteToggle"
@@ -209,6 +208,7 @@
                             <i class="far fa-heart" aria-hidden="true"></i>
                         </button>
                     </div>
+                    <div class="current-song-artist" id="currentSongArtist">未知艺术家</div>
                     <button class="mobile-quality-chip" id="mobileQualityToggle" type="button" aria-haspopup="menu" aria-expanded="false">
                         <span id="mobileQualityLabel">极高音质</span>
                         <i class="fas fa-chevron-down" aria-hidden="true"></i>

--- a/index.html
+++ b/index.html
@@ -147,11 +147,29 @@
             </div>
             <div id="searchResults" class="search-results">
                 <div class="search-results-toolbar">
-                    <button id="importSelectedBtn" class="import-selected-btn" type="button" disabled>
-                        <i class="fas fa-file-import" aria-hidden="true"></i>
-                        <span class="import-selected-label">导入已选</span>
-                        <span id="importSelectedCount" class="import-selected-count" aria-hidden="true"></span>
-                    </button>
+                    <div class="import-dropdown">
+                        <button
+                            id="importSelectedBtn"
+                            class="import-selected-btn"
+                            type="button"
+                            disabled
+                            aria-haspopup="menu"
+                            aria-expanded="false"
+                        >
+                            <i class="fas fa-file-import" aria-hidden="true"></i>
+                            <span class="import-selected-label">导入已选</span>
+                            <span id="importSelectedCount" class="import-selected-count" aria-hidden="true"></span>
+                            <i class="fas fa-caret-down import-dropdown-caret" aria-hidden="true"></i>
+                        </button>
+                        <div class="import-dropdown-menu" id="importSelectedMenu" role="menu" hidden>
+                            <button id="importToPlaylist" class="import-dropdown-item" type="button" role="menuitem">
+                                导入到播放列表
+                            </button>
+                            <button id="importToFavorites" class="import-dropdown-item" type="button" role="menuitem">
+                                导入到收藏列表
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 <div id="searchResultsList" class="search-results-list"></div>
             </div>
@@ -180,6 +198,17 @@
                 <div class="current-song-info">
                     <div class="current-song-title" id="currentSongTitle">选择一首歌曲开始播放</div>
                     <div class="current-song-artist" id="currentSongArtist">未知艺术家</div>
+                    <div class="current-song-actions">
+                        <button
+                            class="favorite-toggle current-favorite-btn"
+                            id="currentFavoriteToggle"
+                            type="button"
+                            aria-label="收藏当前歌曲"
+                            title="收藏当前歌曲"
+                        >
+                            <i class="far fa-heart" aria-hidden="true"></i>
+                        </button>
+                    </div>
                     <button class="mobile-quality-chip" id="mobileQualityToggle" type="button" aria-haspopup="menu" aria-expanded="false">
                         <span id="mobileQualityLabel">极高音质</span>
                         <i class="fas fa-chevron-down" aria-hidden="true"></i>
@@ -230,7 +259,30 @@
                     </div>
                 </div>
 
-                <div class="playlist active empty" id="playlist">
+                <div class="playlist-tabs" role="tablist">
+                    <button
+                        id="playlistTab"
+                        class="playlist-tab active"
+                        type="button"
+                        role="tab"
+                        aria-selected="true"
+                        data-target="playlist"
+                    >
+                        播放列表
+                    </button>
+                    <button
+                        id="favoritesTab"
+                        class="playlist-tab"
+                        type="button"
+                        role="tab"
+                        aria-selected="false"
+                        data-target="favorites"
+                    >
+                        收藏列表
+                    </button>
+                </div>
+
+                <div class="playlist active empty" id="playlist" role="tabpanel" aria-labelledby="playlistTab">
                     <div class="playlist-header">
                         <div class="playlist-label" aria-hidden="true">播放列表</div>
                         <div class="playlist-actions-tray" role="group" aria-label="播放列表操作">
@@ -273,6 +325,59 @@
                     </div>
                     <div class="playlist-scroll">
                         <div class="playlist-items" id="playlistItems"></div>
+                    </div>
+                </div>
+                <div class="favorites empty" id="favorites" role="tabpanel" aria-labelledby="favoritesTab" hidden>
+                    <div class="playlist-header">
+                        <div class="playlist-label" aria-hidden="true">收藏列表</div>
+                        <div class="playlist-actions-tray" role="group" aria-label="收藏列表操作">
+                            <button
+                                class="playlist-action-btn"
+                                id="addAllFavoritesBtn"
+                                type="button"
+                                title="全部添加到播放列表"
+                                aria-label="全部添加到播放列表"
+                            >
+                                <i class="fas fa-plus-circle" aria-hidden="true"></i>
+                            </button>
+                            <input
+                                id="importFavoritesInput"
+                                class="playlist-import-input"
+                                type="file"
+                                accept="application/json"
+                                hidden
+                            />
+                            <button
+                                class="playlist-action-btn"
+                                id="importFavoritesBtn"
+                                type="button"
+                                title="导入收藏列表"
+                                aria-label="导入收藏列表"
+                            >
+                                <i class="fas fa-file-import" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                class="playlist-action-btn"
+                                id="exportFavoritesBtn"
+                                type="button"
+                                title="导出收藏列表"
+                                aria-label="导出收藏列表"
+                            >
+                                <i class="fas fa-file-export" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                class="playlist-action-btn"
+                                id="clearFavoritesBtn"
+                                type="button"
+                                title="清空收藏列表"
+                                aria-label="清空收藏列表"
+                            >
+                                <i class="fas fa-trash" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="playlist-scroll">
+                        <div class="playlist-items" id="favoriteItems"></div>
                     </div>
                 </div>
                 <div class="lyrics empty" id="lyrics" data-placeholder="default">

--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
                         <div class="playlist-items" id="playlistItems"></div>
                     </div>
                 </div>
-                <div class="favorites empty" id="favorites" role="tabpanel" aria-labelledby="favoritesTab" hidden>
+                <div class="playlist favorites empty" id="favorites" role="tabpanel" aria-labelledby="favoritesTab" hidden>
                     <div class="playlist-header">
                         <div class="playlist-actions-tray" role="group" aria-label="收藏列表操作">
                             <button

--- a/index.html
+++ b/index.html
@@ -344,6 +344,24 @@
                 </div>
                 <div class="playlist favorites empty" id="favorites" role="tabpanel" aria-labelledby="favoritesTab" hidden>
                     <div class="playlist-header">
+                        <div class="playlist-tabs" role="tablist">
+                            <button
+                                id="playlistTabSecondary"
+                                class="playlist-tab active"
+                                type="button"
+                                role="tab"
+                                aria-selected="true"
+                                data-target="playlist"
+                            >播放列表</button>
+                            <button
+                                id="favoritesTabSecondary"
+                                class="playlist-tab"
+                                type="button"
+                                role="tab"
+                                aria-selected="false"
+                                data-target="favorites"
+                            >收藏列表</button>
+                        </div>
                         <div class="playlist-actions-tray" role="group" aria-label="收藏列表操作">
                             <button
                                 class="playlist-action-btn"

--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
                                 <i class="fas fa-file-export" aria-hidden="true"></i>
                             </button>
                             <button
-                                class="playlist-action-btn"
+                                class="playlist-action-btn playlist-action-btn--clear"
                                 id="clearFavoritesBtn"
                                 type="button"
                                 title="清空收藏列表"

--- a/index.html
+++ b/index.html
@@ -242,38 +242,80 @@
                         </button>
                     </div>
                     <div class="mobile-panel-actions">
-                        <button
-                            id="mobileImportPlaylistBtn"
-                            class="mobile-panel-action-btn"
-                            type="button"
-                            aria-label="导入播放列表"
-                            title="导入播放列表"
-                        >
-                            <i class="fas fa-file-import" aria-hidden="true"></i>
-                        </button>
-                        <button
-                            id="mobileExportPlaylistBtn"
-                            class="mobile-panel-action-btn"
-                            type="button"
-                            aria-label="导出播放列表"
-                            title="导出播放列表"
-                            aria-disabled="true"
-                            disabled
-                        >
-                            <i class="fas fa-file-export" aria-hidden="true"></i>
-                        </button>
-                        <button
-                            id="mobileClearPlaylistBtn"
-                            class="mobile-panel-action-btn mobile-panel-clear-btn"
-                            type="button"
-                            aria-label="清空播放列表"
-                            title="清空播放列表"
-                            onclick="clearPlaylist()"
-                            hidden
-                            aria-hidden="true"
-                        >
-                            <i class="fas fa-trash" aria-hidden="true"></i>
-                        </button>
+                        <div class="mobile-actions-group" id="mobilePlaylistActions" role="group" aria-label="播放列表操作" aria-hidden="false">
+                            <button
+                                id="mobileImportPlaylistBtn"
+                                class="mobile-panel-action-btn"
+                                type="button"
+                                aria-label="导入播放列表"
+                                title="导入播放列表"
+                            >
+                                <i class="fas fa-file-import" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                id="mobileExportPlaylistBtn"
+                                class="mobile-panel-action-btn"
+                                type="button"
+                                aria-label="导出播放列表"
+                                title="导出播放列表"
+                                aria-disabled="true"
+                                disabled
+                            >
+                                <i class="fas fa-file-export" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                id="mobileClearPlaylistBtn"
+                                class="mobile-panel-action-btn mobile-panel-clear-btn"
+                                type="button"
+                                aria-label="清空播放列表"
+                                title="清空播放列表"
+                                onclick="clearPlaylist()"
+                                hidden
+                                aria-hidden="true"
+                            >
+                                <i class="fas fa-trash" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                        <div class="mobile-actions-group" id="mobileFavoritesActions" role="group" aria-label="收藏列表操作" hidden aria-hidden="true">
+                            <button
+                                id="mobileAddAllFavoritesBtn"
+                                class="mobile-panel-action-btn"
+                                type="button"
+                                aria-label="全部添加到播放列表"
+                                title="全部添加到播放列表"
+                            >
+                                <i class="fas fa-plus-circle" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                id="mobileImportFavoritesBtn"
+                                class="mobile-panel-action-btn"
+                                type="button"
+                                aria-label="导入收藏列表"
+                                title="导入收藏列表"
+                            >
+                                <i class="fas fa-file-import" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                id="mobileExportFavoritesBtn"
+                                class="mobile-panel-action-btn"
+                                type="button"
+                                aria-label="导出收藏列表"
+                                title="导出收藏列表"
+                                aria-disabled="true"
+                                disabled
+                            >
+                                <i class="fas fa-file-export" aria-hidden="true"></i>
+                            </button>
+                            <button
+                                id="mobileClearFavoritesBtn"
+                                class="mobile-panel-action-btn mobile-panel-clear-btn"
+                                type="button"
+                                aria-label="清空收藏列表"
+                                title="清空收藏列表"
+                            >
+                                <i class="fas fa-trash" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <button id="mobilePanelClose" class="mobile-close-btn mobile-panel-action-btn" type="button" aria-label="收起播放面板">
                             <i class="fas fa-chevron-down" aria-hidden="true"></i>
                         </button>

--- a/js/index.js
+++ b/js/index.js
@@ -1468,6 +1468,8 @@ async function updateDynamicBackground(imageUrl) {
         return;
     }
 
+    debugLog(`动态背景: 更新至新的图片 ${imageUrl}`);
+
     if (paletteAbortController) {
         paletteAbortController.abort();
         paletteAbortController = null;
@@ -1505,6 +1507,7 @@ async function updateDynamicBackground(imageUrl) {
             return;
         }
         console.warn("获取动态背景失败:", error);
+        debugLog(`动态背景加载失败: ${error}`);
         if (requestId === paletteRequestId) {
             resetDynamicBackground();
         }
@@ -1543,7 +1546,14 @@ function debugLog(message) {
     console.log(`[DEBUG] ${message}`);
     if (state.debugMode) {
         const debugInfo = dom.debugInfo;
-        debugInfo.innerHTML += `<div>${new Date().toLocaleTimeString()}: ${message}</div>`;
+        const entry = document.createElement("div");
+        entry.textContent = `${new Date().toLocaleTimeString()}: ${message}`;
+        debugInfo.appendChild(entry);
+
+        while (debugInfo.childNodes.length > 50) {
+            debugInfo.removeChild(debugInfo.firstChild);
+        }
+
         debugInfo.classList.add("show");
         debugInfo.scrollTop = debugInfo.scrollHeight;
     }
@@ -5083,12 +5093,14 @@ async function loadLyrics(song) {
             parseLyrics(lyricData.lyric);
             dom.lyrics.classList.remove("empty");
             dom.lyrics.dataset.placeholder = "default";
+            debugLog(`歌词加载成功: ${state.lyricsData.length} 行`);
         } else {
             setLyricsContentHtml("<div>暂无歌词</div>");
             dom.lyrics.classList.add("empty");
             dom.lyrics.dataset.placeholder = "message";
             state.lyricsData = [];
             state.currentLyricLine = -1;
+            debugLog("歌词加载失败: 无歌词数据");
         }
     } catch (error) {
         console.error("加载歌词失败:", error);
@@ -5097,6 +5109,7 @@ async function loadLyrics(song) {
         dom.lyrics.dataset.placeholder = "message";
         state.lyricsData = [];
         state.currentLyricLine = -1;
+        debugLog(`歌词加载失败: ${error}`);
     }
 }
 
@@ -5122,6 +5135,7 @@ function parseLyrics(lyricText) {
 
     state.lyricsData = lyrics.sort((a, b) => a.time - b.time);
     displayLyrics();
+    debugLog(`解析歌词完成: ${state.lyricsData.length} 行`);
 }
 
 function setLyricsContentHtml(html) {
@@ -5236,7 +5250,6 @@ function scrollToCurrentLyric(element, containerOverride) {
         }
     }
 
-    debugLog(`歌词滚动: 元素在容器内偏移=${elementOffsetTop}, 容器高度=${containerHeight}, 目标滚动=${finalScrollTop}`);
 }
 
 // 修复：下载歌曲

--- a/js/index.js
+++ b/js/index.js
@@ -61,11 +61,12 @@ const dom = {
     mobileQualityToggle: document.getElementById("mobileQualityToggle"),
     mobileQualityLabel: document.getElementById("mobileQualityLabel"),
     mobilePanel: document.getElementById("mobilePanel"),
-    mobilePanelTitle: document.getElementById("mobilePanelTitle"),
     mobileQueueToggle: document.getElementById("mobileQueueToggle"),
     searchArea: document.getElementById("searchArea"),
     playlistTab: document.getElementById("playlistTab"),
     favoritesTab: document.getElementById("favoritesTab"),
+    mobilePlaylistTab: document.getElementById("mobilePlaylistTab"),
+    mobileFavoritesTab: document.getElementById("mobileFavoritesTab"),
     addAllFavoritesBtn: document.getElementById("addAllFavoritesBtn"),
     importFavoritesBtn: document.getElementById("importFavoritesBtn"),
     exportFavoritesBtn: document.getElementById("exportFavoritesBtn"),
@@ -148,7 +149,8 @@ function updateMobileClearPlaylistVisibility() {
     const isPlaylistView = !body || !currentView || currentView === "playlist";
     const playlistSongs = (typeof state !== "undefined" && Array.isArray(state.playlistSongs)) ? state.playlistSongs : [];
     const isEmpty = playlistSongs.length === 0 || !playlistElement || playlistElement.classList.contains("empty");
-    const shouldShow = isPlaylistView && !isEmpty;
+    const isPlaylistVisible = Boolean(playlistElement && !playlistElement.hasAttribute("hidden"));
+    const shouldShow = isPlaylistView && isPlaylistVisible && !isEmpty;
     button.hidden = !shouldShow;
     button.setAttribute("aria-hidden", shouldShow ? "false" : "true");
 }
@@ -2592,6 +2594,14 @@ function setupInteractions() {
         dom.favoritesTab.addEventListener("click", () => switchLibraryTab("favorites"));
     }
 
+    if (dom.mobilePlaylistTab) {
+        dom.mobilePlaylistTab.addEventListener("click", () => switchLibraryTab("playlist"));
+    }
+
+    if (dom.mobileFavoritesTab) {
+        dom.mobileFavoritesTab.addEventListener("click", () => switchLibraryTab("favorites"));
+    }
+
     if (dom.importSelectedBtn) {
         dom.importSelectedBtn.addEventListener("click", (event) => {
             event.preventDefault();
@@ -3947,6 +3957,16 @@ function switchLibraryTab(target) {
         dom.favoritesTab.setAttribute("aria-selected", showFavorites ? "true" : "false");
     }
 
+    if (dom.mobilePlaylistTab) {
+        dom.mobilePlaylistTab.classList.toggle("active", !showFavorites);
+        dom.mobilePlaylistTab.setAttribute("aria-selected", showFavorites ? "false" : "true");
+    }
+
+    if (dom.mobileFavoritesTab) {
+        dom.mobileFavoritesTab.classList.toggle("active", showFavorites);
+        dom.mobileFavoritesTab.setAttribute("aria-selected", showFavorites ? "true" : "false");
+    }
+
     if (dom.playlist) {
         if (showFavorites) {
             dom.playlist.classList.remove("active");
@@ -5159,9 +5179,6 @@ function switchMobileView(view) {
     }
     if (isMobileView && document.body) {
         document.body.setAttribute("data-mobile-panel-view", view);
-        if (dom.mobilePanelTitle) {
-            dom.mobilePanelTitle.textContent = view === "lyrics" ? "歌词" : "播放列表";
-        }
         updateMobileClearPlaylistVisibility();
     }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -56,6 +56,12 @@ const dom = {
     mobileSearchClose: document.getElementById("mobileSearchClose"),
     mobilePanelClose: document.getElementById("mobilePanelClose"),
     mobileClearPlaylistBtn: document.getElementById("mobileClearPlaylistBtn"),
+    mobilePlaylistActions: document.getElementById("mobilePlaylistActions"),
+    mobileFavoritesActions: document.getElementById("mobileFavoritesActions"),
+    mobileAddAllFavoritesBtn: document.getElementById("mobileAddAllFavoritesBtn"),
+    mobileImportFavoritesBtn: document.getElementById("mobileImportFavoritesBtn"),
+    mobileExportFavoritesBtn: document.getElementById("mobileExportFavoritesBtn"),
+    mobileClearFavoritesBtn: document.getElementById("mobileClearFavoritesBtn"),
     mobileOverlayScrim: document.getElementById("mobileOverlayScrim"),
     mobileExploreButton: document.getElementById("mobileExploreButton"),
     mobileQualityToggle: document.getElementById("mobileQualityToggle"),
@@ -150,6 +156,35 @@ function updateMobileClearPlaylistVisibility() {
     const shouldShow = isPlaylistView && isPlaylistVisible && !isEmpty;
     button.hidden = !shouldShow;
     button.setAttribute("aria-hidden", shouldShow ? "false" : "true");
+}
+
+function updateMobileLibraryActionVisibility(showFavorites) {
+    if (!isMobileView) {
+        return;
+    }
+    const playlistGroup = dom.mobilePlaylistActions;
+    const favoritesGroup = dom.mobileFavoritesActions;
+    const showFavoritesGroup = Boolean(showFavorites);
+
+    if (playlistGroup) {
+        if (showFavoritesGroup) {
+            playlistGroup.setAttribute("hidden", "");
+            playlistGroup.setAttribute("aria-hidden", "true");
+        } else {
+            playlistGroup.removeAttribute("hidden");
+            playlistGroup.setAttribute("aria-hidden", "false");
+        }
+    }
+
+    if (favoritesGroup) {
+        if (showFavoritesGroup) {
+            favoritesGroup.removeAttribute("hidden");
+            favoritesGroup.setAttribute("aria-hidden", "false");
+        } else {
+            favoritesGroup.setAttribute("hidden", "");
+            favoritesGroup.setAttribute("aria-hidden", "true");
+        }
+    }
 }
 
 function forceCloseMobileSearchOverlay() {
@@ -2574,6 +2609,25 @@ function setupInteractions() {
         dom.clearFavoritesBtn.addEventListener("click", clearFavorites);
     }
 
+    if (dom.mobileAddAllFavoritesBtn) {
+        dom.mobileAddAllFavoritesBtn.addEventListener("click", addAllFavoritesToPlaylist);
+    }
+
+    if (dom.mobileImportFavoritesBtn && dom.importFavoritesInput) {
+        dom.mobileImportFavoritesBtn.addEventListener("click", () => {
+            dom.importFavoritesInput.value = "";
+            dom.importFavoritesInput.click();
+        });
+    }
+
+    if (dom.mobileExportFavoritesBtn) {
+        dom.mobileExportFavoritesBtn.addEventListener("click", exportFavorites);
+    }
+
+    if (dom.mobileClearFavoritesBtn) {
+        dom.mobileClearFavoritesBtn.addEventListener("click", clearFavorites);
+    }
+
     if (dom.currentFavoriteToggle) {
         dom.currentFavoriteToggle.addEventListener("click", () => {
             if (!state.currentSong) {
@@ -3972,6 +4026,7 @@ function switchLibraryTab(target) {
         }
     }
 
+    updateMobileLibraryActionVisibility(showFavorites);
     updateMobileClearPlaylistVisibility();
     closeImportSelectedMenu();
 }
@@ -4065,13 +4120,25 @@ function updateFavoriteActionStates() {
         dom.exportFavoritesBtn.disabled = !hasFavorites;
         dom.exportFavoritesBtn.setAttribute("aria-disabled", hasFavorites ? "false" : "true");
     }
+    if (dom.mobileExportFavoritesBtn) {
+        dom.mobileExportFavoritesBtn.disabled = !hasFavorites;
+        dom.mobileExportFavoritesBtn.setAttribute("aria-disabled", hasFavorites ? "false" : "true");
+    }
     if (dom.clearFavoritesBtn) {
         dom.clearFavoritesBtn.disabled = !hasFavorites;
         dom.clearFavoritesBtn.setAttribute("aria-disabled", hasFavorites ? "false" : "true");
     }
+    if (dom.mobileClearFavoritesBtn) {
+        dom.mobileClearFavoritesBtn.disabled = !hasFavorites;
+        dom.mobileClearFavoritesBtn.setAttribute("aria-disabled", hasFavorites ? "false" : "true");
+    }
     if (dom.addAllFavoritesBtn) {
         dom.addAllFavoritesBtn.disabled = !hasFavorites;
         dom.addAllFavoritesBtn.setAttribute("aria-disabled", hasFavorites ? "false" : "true");
+    }
+    if (dom.mobileAddAllFavoritesBtn) {
+        dom.mobileAddAllFavoritesBtn.disabled = !hasFavorites;
+        dom.mobileAddAllFavoritesBtn.setAttribute("aria-disabled", hasFavorites ? "false" : "true");
     }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -3851,7 +3851,7 @@ function renderPlaylist() {
         return `
         <div class="playlist-item" data-index="${index}" role="button" tabindex="0" aria-label="播放 ${song.name}" data-favorite-key="${songKey}">
             ${song.name} - ${artistValue}
-            <button class="playlist-item-favorite favorite-toggle" type="button" data-playlist-action="favorite" data-index="${index}" data-favorite-key="${songKey}" title="收藏" aria-label="收藏">
+            <button class="playlist-item-favorite action-btn favorite favorite-toggle" type="button" data-playlist-action="favorite" data-index="${index}" data-favorite-key="${songKey}" title="收藏" aria-label="收藏">
                 <i class="fa-regular fa-heart"></i>
             </button>
             <button class="playlist-item-download" type="button" data-playlist-action="download" data-index="${index}" title="下载">

--- a/js/index.js
+++ b/js/index.js
@@ -63,10 +63,7 @@ const dom = {
     mobilePanel: document.getElementById("mobilePanel"),
     mobileQueueToggle: document.getElementById("mobileQueueToggle"),
     searchArea: document.getElementById("searchArea"),
-    playlistTab: document.getElementById("playlistTab"),
-    favoritesTab: document.getElementById("favoritesTab"),
-    mobilePlaylistTab: document.getElementById("mobilePlaylistTab"),
-    mobileFavoritesTab: document.getElementById("mobileFavoritesTab"),
+    libraryTabs: Array.from(document.querySelectorAll(".playlist-tab[data-target]")),
     addAllFavoritesBtn: document.getElementById("addAllFavoritesBtn"),
     importFavoritesBtn: document.getElementById("importFavoritesBtn"),
     exportFavoritesBtn: document.getElementById("exportFavoritesBtn"),
@@ -2586,20 +2583,16 @@ function setupInteractions() {
         });
     }
 
-    if (dom.playlistTab) {
-        dom.playlistTab.addEventListener("click", () => switchLibraryTab("playlist"));
-    }
-
-    if (dom.favoritesTab) {
-        dom.favoritesTab.addEventListener("click", () => switchLibraryTab("favorites"));
-    }
-
-    if (dom.mobilePlaylistTab) {
-        dom.mobilePlaylistTab.addEventListener("click", () => switchLibraryTab("playlist"));
-    }
-
-    if (dom.mobileFavoritesTab) {
-        dom.mobileFavoritesTab.addEventListener("click", () => switchLibraryTab("favorites"));
+    if (Array.isArray(dom.libraryTabs) && dom.libraryTabs.length > 0) {
+        dom.libraryTabs.forEach((tab) => {
+            if (!(tab instanceof HTMLElement)) {
+                return;
+            }
+            tab.addEventListener("click", () => {
+                const target = tab.dataset.target === "favorites" ? "favorites" : "playlist";
+                switchLibraryTab(target);
+            });
+        });
     }
 
     if (dom.importSelectedBtn) {
@@ -3947,24 +3940,16 @@ function updateFavoriteIcons() {
 function switchLibraryTab(target) {
     const showFavorites = target === "favorites";
 
-    if (dom.playlistTab) {
-        dom.playlistTab.classList.toggle("active", !showFavorites);
-        dom.playlistTab.setAttribute("aria-selected", showFavorites ? "false" : "true");
-    }
-
-    if (dom.favoritesTab) {
-        dom.favoritesTab.classList.toggle("active", showFavorites);
-        dom.favoritesTab.setAttribute("aria-selected", showFavorites ? "true" : "false");
-    }
-
-    if (dom.mobilePlaylistTab) {
-        dom.mobilePlaylistTab.classList.toggle("active", !showFavorites);
-        dom.mobilePlaylistTab.setAttribute("aria-selected", showFavorites ? "false" : "true");
-    }
-
-    if (dom.mobileFavoritesTab) {
-        dom.mobileFavoritesTab.classList.toggle("active", showFavorites);
-        dom.mobileFavoritesTab.setAttribute("aria-selected", showFavorites ? "true" : "false");
+    if (Array.isArray(dom.libraryTabs) && dom.libraryTabs.length > 0) {
+        dom.libraryTabs.forEach((tab) => {
+            if (!(tab instanceof HTMLElement)) {
+                return;
+            }
+            const target = tab.dataset.target === "favorites" ? "favorites" : "playlist";
+            const isActive = showFavorites ? target === "favorites" : target === "playlist";
+            tab.classList.toggle("active", isActive);
+            tab.setAttribute("aria-selected", isActive ? "true" : "false");
+        });
     }
 
     if (dom.playlist) {

--- a/js/index.js
+++ b/js/index.js
@@ -3052,16 +3052,6 @@ function createSearchResultItem(song, index) {
     const actions = document.createElement("div");
     actions.className = "search-result-actions";
 
-    const playButton = document.createElement("button");
-    playButton.className = "action-btn play";
-    playButton.type = "button";
-    playButton.title = "播放";
-    playButton.innerHTML = '<i class="fas fa-play"></i> 播放';
-    playButton.addEventListener("click", (event) => {
-        event.stopPropagation();
-        playSearchResult(index);
-    });
-
     const favoriteButton = document.createElement("button");
     favoriteButton.className = "action-btn favorite favorite-toggle";
     favoriteButton.type = "button";
@@ -3071,6 +3061,16 @@ function createSearchResultItem(song, index) {
     favoriteButton.addEventListener("click", (event) => {
         event.stopPropagation();
         toggleFavorite(song);
+    });
+
+    const playButton = document.createElement("button");
+    playButton.className = "action-btn play";
+    playButton.type = "button";
+    playButton.title = "播放";
+    playButton.innerHTML = '<i class="fas fa-play"></i>';
+    playButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        playSearchResult(index);
     });
 
     const downloadButton = document.createElement("button");
@@ -3105,8 +3105,8 @@ function createSearchResultItem(song, index) {
 
     downloadButton.appendChild(qualityMenu);
 
-    actions.appendChild(playButton);
     actions.appendChild(favoriteButton);
+    actions.appendChild(playButton);
     actions.appendChild(downloadButton);
 
     item.appendChild(selectionToggle);
@@ -3854,11 +3854,11 @@ function renderPlaylist() {
             <button class="playlist-item-favorite favorite-toggle" type="button" data-playlist-action="favorite" data-index="${index}" data-favorite-key="${songKey}" title="收藏" aria-label="收藏">
                 <i class="fa-regular fa-heart"></i>
             </button>
-            <button class="playlist-item-remove" type="button" data-playlist-action="remove" data-index="${index}" title="从播放列表移除">
-                <i class="fas fa-times"></i>
-            </button>
             <button class="playlist-item-download" type="button" data-playlist-action="download" data-index="${index}" title="下载">
                 <i class="fas fa-download"></i>
+            </button>
+            <button class="playlist-item-remove" type="button" data-playlist-action="remove" data-index="${index}" title="从播放列表移除">
+                <i class="fas fa-times"></i>
             </button>
         </div>`;
     }).join("");

--- a/login.html
+++ b/login.html
@@ -492,7 +492,8 @@
           <label for="password" class="field-label">访问口令</label>
           <div class="input-wrapper">
             <i class="fa-solid fa-lock" aria-hidden="true"></i>
-            <input type="password" id="password" placeholder="请输入密码" autocomplete="current-password" required>
+            <input type="password" id="password" placeholder="请输入密码" autocomplete="current-password" required
+              oninput="this.value = this.value.replace(/[^\x00-\x7F]/g, '')">
           </div>
         </div>
         <p class="login-hint">只有输入了正确口令的成员才能继续访问内容。</p>


### PR DESCRIPTION
## Summary
- only register the auto-play-next handler when the Media Session API is unavailable, preventing double skips

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690cdae421e8832a94d613d99ba24d56