### PR TITLE
Fix playlist hover actions staying visible after pointer leave

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2356,6 +2356,10 @@ function setupInteractions() {
             }
 
             activatePlaylistItem(index);
+
+            if (event.detail !== 0 && typeof item.blur === "function") {
+                item.blur();
+            }
         };
 
         const handleKeydown = (event) => {


### PR DESCRIPTION
## Summary
- blur playlist items after pointer activation so hover controls hide when the cursor leaves
- guard the blur call to avoid affecting keyboard-triggered activation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ec7bd34e8832ab9314c4efa4c6013)