### PR TITLE
Align desktop controls with lyrics column

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1565,11 +1565,12 @@ html.mobile-view .favorites .favorite-item-action--remove {
 /* 控制区域 */
 .controls {
     grid-area: controls;
-    display: flex;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr) minmax(0, 1fr) auto;
     align-items: center;
-    gap: 20px;
-    flex-wrap: wrap;
+    column-gap: 20px;
+    row-gap: 12px;
+    width: 100%;
     transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .controls button {
@@ -1601,6 +1602,7 @@ html.mobile-view .favorites .favorite-item-action--remove {
     border-radius: 25px;
     padding: 0 25px;
     gap: 10px;
+    justify-self: flex-end;
 }
 .controls button#loadOnlineBtn .btn-text {
     display: inline-flex;
@@ -1626,6 +1628,7 @@ html.mobile-view .favorites .favorite-item-action--remove {
     display: flex;
     align-items: center;
     gap: 12px;
+    justify-self: flex-start;
 }
 
 html:not(.mobile-view) #playModeBtn {
@@ -1646,8 +1649,9 @@ html:not(.mobile-view) #playModeBtn {
     display: flex;
     align-items: center;
     gap: 12px;
-    flex: 1 1 320px;
     min-width: 260px;
+    width: 100%;
+    justify-self: stretch;
 }
 
 .progress-container span {
@@ -1668,19 +1672,20 @@ html:not(.mobile-view) #playModeBtn {
 .audio-tools {
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 16px;
     flex-wrap: wrap;
+    justify-self: flex-start;
 }
 
 .volume-container {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     min-width: 140px;
 }
 
 .volume-container input[type="range"] {
-    width: 120px;
+    width: 110px;
     height: 6px;
     border-radius: 999px;
     background: linear-gradient(to right, var(--primary-color) 0%, var(--primary-color) var(--volume-progress, 100%), rgba(255, 255, 255, 0.2) var(--volume-progress, 100%), rgba(255, 255, 255, 0.1) 100%);

--- a/css/style.css
+++ b/css/style.css
@@ -1566,7 +1566,8 @@ html.mobile-view .favorites .favorite-item-action--remove {
 .controls {
     grid-area: controls;
     display: grid;
-    grid-template-columns: 300px minmax(0, 1fr) minmax(0, 1fr) auto;
+    grid-template-columns: 300px minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-areas: "transport progress trailing";
     align-items: center;
     column-gap: 20px;
     row-gap: 12px;
@@ -1602,7 +1603,6 @@ html.mobile-view .favorites .favorite-item-action--remove {
     border-radius: 25px;
     padding: 0 25px;
     gap: 10px;
-    justify-self: flex-end;
 }
 .controls button#loadOnlineBtn .btn-text {
     display: inline-flex;
@@ -1625,6 +1625,7 @@ html.mobile-view .favorites .favorite-item-action--remove {
     box-shadow: none; 
 }
 .transport-controls {
+    grid-area: transport;
     display: flex;
     align-items: center;
     gap: 12px;
@@ -1646,12 +1647,23 @@ html:not(.mobile-view) #playModeBtn {
 }
 
 .progress-container {
+    grid-area: progress;
     display: flex;
     align-items: center;
     gap: 12px;
     min-width: 260px;
     width: 100%;
     justify-self: stretch;
+}
+
+.control-trailing {
+    grid-area: trailing;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    width: 100%;
+    flex-wrap: wrap;
 }
 
 .progress-container span {
@@ -1674,7 +1686,12 @@ html:not(.mobile-view) #playModeBtn {
     align-items: center;
     gap: 16px;
     flex-wrap: wrap;
-    justify-self: flex-start;
+    justify-content: flex-start;
+    flex: 1 1 auto;
+}
+
+.control-trailing #loadOnlineBtn {
+    margin-left: auto;
 }
 
 .volume-container {

--- a/index.html
+++ b/index.html
@@ -477,22 +477,24 @@
                 <input type="range" id="progressBar" min="0" max="0" step="0.1" value="0">
                 <span id="durationDisplay">00:00</span>
             </div>
-            <div class="audio-tools">
-                <div class="player-quality">
-                    <button id="qualityToggle" class="player-quality-btn" type="button">
-                        <span id="qualityLabel">极高音质</span>
-                    </button>
-                    <div id="playerQualityMenu" class="player-quality-menu"></div>
+            <div class="control-trailing">
+                <div class="audio-tools">
+                    <div class="player-quality">
+                        <button id="qualityToggle" class="player-quality-btn" type="button">
+                            <span id="qualityLabel">极高音质</span>
+                        </button>
+                        <div id="playerQualityMenu" class="player-quality-menu"></div>
+                    </div>
+                    <div class="volume-container">
+                        <i id="volumeIcon" class="fas fa-volume-up"></i>
+                        <input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.8">
+                    </div>
                 </div>
-                <div class="volume-container">
-                    <i id="volumeIcon" class="fas fa-volume-up"></i>
-                    <input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.8">
-                </div>
+                <button id="loadOnlineBtn" title="聚合所有雷达，探索新音乐">
+                    <span class="btn-text"><i class="fas fa-satellite-dish"></i> 探索雷达</span>
+                    <span class="loader" style="display: none;"></span>
+                </button>
             </div>
-            <button id="loadOnlineBtn" title="聚合所有雷达，探索新音乐">
-                <span class="btn-text"><i class="fas fa-satellite-dish"></i> 探索雷达</span>
-                <span class="loader" style="display: none;"></span>
-            </button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- adjust the desktop control bar to use a grid layout so the quality selector aligns with the lyrics column
- tighten the spacing between the quality selector, volume slider, and explore button to keep the controls balanced

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ec9d8b2bc832a9f68f6dd17b0fd7d)