### PR TITLE
Fix: Integrate shuffle into play mode button for mobile view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1874,6 +1874,13 @@ input[type="range"]:active::-moz-range-thumb {
     align-items: center;
 }
 
+/* 移动端适配：隐藏独立的随机播放按钮（#shuffleToggleBtn） */
+@media (max-width: 820px) {
+    .transport-button--shuffle {
+        display: none !important;
+    }
+}
+
 .play-mode-btn {
     background: var(--primary-color);
     color: white;


### PR DESCRIPTION
根据用户反馈，移动端应将随机播放模式整合到播放模式切换按钮（#playModeBtn）中，并移除独立的随机播放按钮（#shuffleToggleBtn）。

本次修复内容：
1. **JS 逻辑修改**：修改  函数，使其在“列表循环” -> “单曲循环” -> “随机播放”三种模式间切换，并同步更新  状态。
2. **CSS 样式修改**：在  中添加媒体查询 ，隐藏独立的随机播放按钮 ，确保 PC 端布局不受影响。

现在移动端用户可以通过点击一个按钮切换所有播放模式，同时 PC 端用户依然拥有独立的随机播放按钮。