### PR TITLE
Support EdgeOne PASSWORD env

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 🔐 访问控制设置
 - **Cloudflare Pages：** 在项目的 **Settings → Functions → Environment variables** 中新增名为 `PASSWORD` 的环境变量，值为希望设置的访问口令。
-- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量即可。仓库已额外提供 `edge-functions/` 目录来映射中间件与 `/api/login`（EdgeOne 仅识别该目录），无需再手动复制函数代码；
+- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量即可。仓库已额外提供 `edge-functions/index.ts`、`edge-functions/[[path]].ts` 与 `/api/login` 入口（EdgeOne 仅识别该目录），用于在所有路径上执行同样的密码校验，无需再手动复制函数代码；
   ⚠️ EdgeOne Pages 节点虽然速度快，但平台目前对音乐/音视频聚合站点的容忍度不高，存在被封禁的潜在风险，部署前请先评估。
 - 部署完成后，未登录的访问者会被自动重定向到 `/login` 页面并需输入该口令；若想关闭访问口令，删除该环境变量并重新部署即可。
 ## 🎵 使用流程
@@ -82,7 +82,8 @@ Music-Player/
 │   ├── palette.ts     # 封面取色算法
 │   └── proxy.ts       # 音频直链代理
 ├── edge-functions/
-│   ├── _middleware.ts # EdgeOne Pages 识别的函数入口，复用 functions/ 中间件
+│   ├── index.ts       # EdgeOne Pages 主页入口，复用密码校验逻辑
+│   ├── [[path]].ts    # EdgeOne catch-all 入口，确保子路径也执行密码校验
 │   └── api/
 │       └── login.ts   # EdgeOne 的登录接口入口，复用 functions/api/login
 ├── js/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 
 ## 🔐 访问控制设置
 - **Cloudflare Pages：** 在项目的 **Settings → Functions → Environment variables** 中新增名为 `PASSWORD` 的环境变量，值为希望设置的访问口令。
+- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量。Functions 与页面会自动读取 EdgeOne 的运行时变量（或构建时的 `process.env.PASSWORD`），不再需要额外改动。
 - 部署完成后，未登录的访问者会被自动重定向到 `/login` 页面并需输入该口令；若想关闭访问口令，删除该环境变量并重新部署即可。
 ## 🎵 使用流程
 1. 输入关键词并选择想要的曲库后发起搜索。

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@
 
 ## 🔐 访问控制设置
 - **Cloudflare Pages：** 在项目的 **Settings → Functions → Environment variables** 中新增名为 `PASSWORD` 的环境变量，值为希望设置的访问口令。
-- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量。Functions 与页面会自动读取 EdgeOne 的运行时变量（或构建时的 `process.env.PASSWORD`），不再需要额外改动；⚠️ EdgeOne Pages 节点虽然速度快，但平台目前对音乐/音视频聚合站点的容忍度不高，存在被封禁的潜在风险，部署前请先评估。
+- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量。Functions 与页面会自动读取 EdgeOne 的运行时变量（或构建时的 `process.env.PASSWORD`），不再需要额外改动；
+  ⚠️ EdgeOne Pages 节点虽然速度快，但平台目前对音乐/音视频聚合站点的容忍度不高，存在被封禁的潜在风险，部署前请先评估。
 - 部署完成后，未登录的访问者会被自动重定向到 `/login` 页面并需输入该口令；若想关闭访问口令，删除该环境变量并重新部署即可。
 ## 🎵 使用流程
 1. 输入关键词并选择想要的曲库后发起搜索。

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 🔐 访问控制设置
 - **Cloudflare Pages：** 在项目的 **Settings → Functions → Environment variables** 中新增名为 `PASSWORD` 的环境变量，值为希望设置的访问口令。
-- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量。Functions 与页面会自动读取 EdgeOne 的运行时变量（或构建时的 `process.env.PASSWORD`），不再需要额外改动。
+- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量。Functions 与页面会自动读取 EdgeOne 的运行时变量（或构建时的 `process.env.PASSWORD`），不再需要额外改动；⚠️ EdgeOne Pages 节点虽然速度快，但平台目前对音乐/音视频聚合站点的容忍度不高，存在被封禁的潜在风险，部署前请先评估。
 - 部署完成后，未登录的访问者会被自动重定向到 `/login` 页面并需输入该口令；若想关闭访问口令，删除该环境变量并重新部署即可。
 ## 🎵 使用流程
 1. 输入关键词并选择想要的曲库后发起搜索。

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 🔐 访问控制设置
 - **Cloudflare Pages：** 在项目的 **Settings → Functions → Environment variables** 中新增名为 `PASSWORD` 的环境变量，值为希望设置的访问口令。
-- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量。Functions 与页面会自动读取 EdgeOne 的运行时变量（或构建时的 `process.env.PASSWORD`），不再需要额外改动；
+- **腾讯云 EdgeOne Pages：** 在控制台的 **站点 → 设置 → 环境变量** 中同样添加 `PASSWORD` 变量即可。仓库已额外提供 `edge-functions/` 目录来映射中间件与 `/api/login`（EdgeOne 仅识别该目录），无需再手动复制函数代码；
   ⚠️ EdgeOne Pages 节点虽然速度快，但平台目前对音乐/音视频聚合站点的容忍度不高，存在被封禁的潜在风险，部署前请先评估。
 - 部署完成后，未登录的访问者会被自动重定向到 `/login` 页面并需输入该口令；若想关闭访问口令，删除该环境变量并重新部署即可。
 ## 🎵 使用流程
@@ -81,6 +81,10 @@ Music-Player/
 │   ├── lib/           # 请求封装与工具模块
 │   ├── palette.ts     # 封面取色算法
 │   └── proxy.ts       # 音频直链代理
+├── edge-functions/
+│   ├── _middleware.ts # EdgeOne Pages 识别的函数入口，复用 functions/ 中间件
+│   └── api/
+│       └── login.ts   # EdgeOne 的登录接口入口，复用 functions/api/login
 ├── js/
 │   ├── index.js       # 播放器核心逻辑、状态管理与探索雷达分类
 │   └── mobile.js      # 移动端交互与事件处理

--- a/edge-functions/[[path]].ts
+++ b/edge-functions/[[path]].ts
@@ -1,0 +1,3 @@
+import { handleEdgeOneRequest } from "./_edgeone-shared";
+
+export { handleEdgeOneRequest as onRequest };

--- a/edge-functions/_edgeone-shared.ts
+++ b/edge-functions/_edgeone-shared.ts
@@ -1,0 +1,30 @@
+import { maybeRedirectToLogin } from "../functions/lib/password-gate";
+
+type EdgeContext = {
+  request: Request;
+  env?: Record<string, any> & {
+    ASSETS?: { fetch: (request: Request) => Promise<Response> };
+  };
+  next?: () => Promise<Response>;
+};
+
+export async function handleEdgeOneRequest(context: EdgeContext) {
+  const redirectResponse = maybeRedirectToLogin(context as any);
+  if (redirectResponse) {
+    return redirectResponse;
+  }
+  return continueRequest(context);
+}
+
+async function continueRequest(context: EdgeContext): Promise<Response> {
+  if (typeof context.next === "function") {
+    return context.next();
+  }
+
+  const assetNamespace = context.env?.ASSETS;
+  if (assetNamespace && typeof assetNamespace.fetch === "function") {
+    return assetNamespace.fetch(context.request);
+  }
+
+  return fetch(context.request);
+}

--- a/edge-functions/_middleware.ts
+++ b/edge-functions/_middleware.ts
@@ -1,0 +1,1 @@
+export { onRequest } from "../functions/_middleware";

--- a/edge-functions/_middleware.ts
+++ b/edge-functions/_middleware.ts
@@ -1,1 +1,0 @@
-export { onRequest } from "../functions/_middleware";

--- a/edge-functions/api/login.ts
+++ b/edge-functions/api/login.ts
@@ -1,0 +1,1 @@
+export { onRequestPost } from "../../functions/api/login";

--- a/edge-functions/index.ts
+++ b/edge-functions/index.ts
@@ -1,0 +1,3 @@
+import { handleEdgeOneRequest } from "./_edgeone-shared";
+
+export { handleEdgeOneRequest as onRequest };

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,71 +1,9 @@
-import { getPasswordFromEnv } from "./lib/get-password";
-
-const PUBLIC_PATH_PATTERNS = [/^\/login(?:\/|$)/, /^\/api\/login(?:\/|$)/];
-const PUBLIC_FILE_EXTENSIONS = new Set([
-  ".css",
-  ".js",
-  ".png",
-  ".svg",
-  ".jpg",
-  ".jpeg",
-  ".gif",
-  ".webp",
-  ".ico",
-  ".txt",
-  ".map",
-  ".json",
-  ".woff",
-  ".woff2",
-]);
-
-function hasPublicExtension(pathname: string): boolean {
-  const lastDotIndex = pathname.lastIndexOf(".");
-  if (lastDotIndex === -1) {
-    return false;
-  }
-  const extension = pathname.slice(lastDotIndex).toLowerCase();
-  return PUBLIC_FILE_EXTENSIONS.has(extension);
-}
-
-function isPublicPath(pathname: string): boolean {
-  return (
-    PUBLIC_PATH_PATTERNS.some((pattern) => pattern.test(pathname)) ||
-    hasPublicExtension(pathname)
-  );
-}
+import { maybeRedirectToLogin } from "./lib/password-gate";
 
 export async function onRequest(context: any) {
-  const { request, env } = context;
-  const password = getPasswordFromEnv(env);
-
-  if (typeof password !== "string") {
-    return context.next();
+  const redirectResponse = maybeRedirectToLogin(context);
+  if (redirectResponse) {
+    return redirectResponse;
   }
-
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-  if (isPublicPath(pathname)) {
-    return context.next();
-  }
-
-  const cookieHeader = request.headers.get("Cookie") || "";
-  const cookies: Record<string, string> = {};
-  cookieHeader.split(";").forEach((part) => {
-    const separatorIndex = part.indexOf("=");
-    if (separatorIndex === -1) {
-      return;
-    }
-    const key = part.slice(0, separatorIndex).trim();
-    const value = part.slice(separatorIndex + 1).trim();
-    if (key) {
-      cookies[key] = value;
-    }
-  });
-
-  if (cookies.auth && cookies.auth === btoa(password)) {
-    return context.next();
-  }
-
-  const loginUrl = new URL("/login", url);
-  return Response.redirect(loginUrl.toString(), 302);
+  return context.next();
 }

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,3 +1,5 @@
+import { getPasswordFromEnv } from "./lib/get-password";
+
 const PUBLIC_PATH_PATTERNS = [/^\/login(?:\/|$)/, /^\/api\/login(?:\/|$)/];
 const PUBLIC_FILE_EXTENSIONS = new Set([
   ".css",
@@ -34,7 +36,7 @@ function isPublicPath(pathname: string): boolean {
 
 export async function onRequest(context: any) {
   const { request, env } = context;
-  const password = env.PASSWORD;
+  const password = getPasswordFromEnv(env);
 
   if (typeof password !== "string") {
     return context.next();

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -1,8 +1,10 @@
+import { getPasswordFromEnv } from "../lib/get-password";
+
 const MAX_AGE_SECONDS = 48 * 60 * 60;
 
 export async function onRequestPost(context: any) {
   const { request, env } = context;
-  const passwordEnv = env.PASSWORD;
+  const passwordEnv = getPasswordFromEnv(env);
   const url = new URL(request.url);
 
   const body = await request.json().catch(() => ({ password: "" }));

--- a/functions/lib/get-password.ts
+++ b/functions/lib/get-password.ts
@@ -1,0 +1,23 @@
+export function getPasswordFromEnv(env: Record<string, unknown>): string | undefined {
+  const passwordFromContext = extractPassword(env?.PASSWORD);
+  if (passwordFromContext) {
+    return passwordFromContext;
+  }
+
+  if (typeof process !== "undefined" && process.env) {
+    const passwordFromProcess = extractPassword(process.env.PASSWORD);
+    if (passwordFromProcess) {
+      return passwordFromProcess;
+    }
+  }
+
+  return undefined;
+}
+
+function extractPassword(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}

--- a/functions/lib/password-gate.ts
+++ b/functions/lib/password-gate.ts
@@ -1,0 +1,71 @@
+import { getPasswordFromEnv } from "./get-password";
+
+const PUBLIC_PATH_PATTERNS = [/^\/login(?:\/|$)/, /^\/api\/login(?:\/|$)/];
+const PUBLIC_FILE_EXTENSIONS = new Set([
+  ".css",
+  ".js",
+  ".png",
+  ".svg",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+  ".txt",
+  ".map",
+  ".json",
+  ".woff",
+  ".woff2",
+]);
+
+function hasPublicExtension(pathname: string): boolean {
+  const lastDotIndex = pathname.lastIndexOf(".");
+  if (lastDotIndex === -1) {
+    return false;
+  }
+  const extension = pathname.slice(lastDotIndex).toLowerCase();
+  return PUBLIC_FILE_EXTENSIONS.has(extension);
+}
+
+function isPublicPath(pathname: string): boolean {
+  return (
+    PUBLIC_PATH_PATTERNS.some((pattern) => pattern.test(pathname)) ||
+    hasPublicExtension(pathname)
+  );
+}
+
+export function maybeRedirectToLogin(context: {
+  request: Request;
+  env: Record<string, unknown>;
+}): Response | null {
+  const password = getPasswordFromEnv(context?.env);
+  if (typeof password !== "string") {
+    return null;
+  }
+
+  const url = new URL(context.request.url);
+  if (isPublicPath(url.pathname)) {
+    return null;
+  }
+
+  const cookieHeader = context.request.headers.get("Cookie") || "";
+  const cookies: Record<string, string> = {};
+  cookieHeader.split(";").forEach((part) => {
+    const separatorIndex = part.indexOf("=");
+    if (separatorIndex === -1) {
+      return;
+    }
+    const key = part.slice(0, separatorIndex).trim();
+    const value = part.slice(separatorIndex + 1).trim();
+    if (key) {
+      cookies[key] = value;
+    }
+  });
+
+  if (cookies.auth && cookies.auth === btoa(password)) {
+    return null;
+  }
+
+  const loginUrl = new URL("/login", url);
+  return Response.redirect(loginUrl.toString(), 302);
+}


### PR DESCRIPTION
## Summary
- add a helper to read the PASSWORD value from either the Pages runtime env or process.env so EdgeOne Pages deployments can enforce the login gate
- update the middleware, login endpoint, and documentation to use the shared helper and document EdgeOne configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6919f9615874832a89f240d9ea1ac552)