### PR TITLE
Add Cloudflare D1 storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,21 @@
 2. 进入新建的数据库详情页，点击 **Settings → Bindings**，创建绑定：
    - **Name** 填写 `DB`（必须与 `functions/api/storage.ts` 中的环境变量一致）。
    - **Pages** 选择当前部署的 Pages 项目并保存。
-3. 在数据库详情页切换到 **Query** 标签页，执行下方建表语句初始化键值存储表：
+3. 在数据库详情页切换到 **Query** 标签页，执行下方建表语句初始化两个独立的键值存储表（播放数据与收藏数据分离）：
    ```sql
-   CREATE TABLE IF NOT EXISTS kv_store (
+   CREATE TABLE IF NOT EXISTS playback_store (
+     key TEXT PRIMARY KEY,
+     value TEXT,
+     updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+   );
+
+   CREATE TABLE IF NOT EXISTS favorites_store (
      key TEXT PRIMARY KEY,
      value TEXT,
      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
    );
    ```
-4. 重新部署或预览站点。前端会优先检测 D1 绑定并将播放列表、收藏等持久化到 `kv_store` 表；未绑定时自动退回浏览器 localStorage。
+4. 重新部署或预览站点。前端会优先检测 D1 绑定：播放状态、播放列表等写入 `playback_store`，收藏相关写入 `favorites_store`；未绑定时自动退回浏览器 localStorage。
 
 ## 🧭 探索雷达
 - 探索雷达会在「流行、摇滚、古典音乐、民谣、电子、爵士、说唱、乡村、蓝调、R&B、金属、嘻哈、轻音乐」等分类中随机挑选关键词，自动为播放列表补充新歌。

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@
 - API 基地址定义在 index.html 中的 `API.baseUrl`（约 1300 行），可替换为自建接口域名。
 - 默认主题、播放模式等偏好可在 `state` 初始化逻辑中按需调整。
 
+### ☁️ Cloudflare D1 绑定与建表
+1. 在 Cloudflare Dashboard 的 **Workers & Pages → D1 → Create** 中新建数据库，建议命名为 `solara-db`（名称可自定）。
+2. 进入新建的数据库详情页，点击 **Settings → Bindings**，创建绑定：
+   - **Name** 填写 `DB`（必须与 `functions/api/storage.ts` 中的环境变量一致）。
+   - **Pages** 选择当前部署的 Pages 项目并保存。
+3. 在数据库详情页切换到 **Query** 标签页，执行下方建表语句初始化键值存储表：
+   ```sql
+   CREATE TABLE IF NOT EXISTS kv_store (
+     key TEXT PRIMARY KEY,
+     value TEXT,
+     updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+   );
+   ```
+4. 重新部署或预览站点。前端会优先检测 D1 绑定并将播放列表、收藏等持久化到 `kv_store` 表；未绑定时自动退回浏览器 localStorage。
+
 ## 🧭 探索雷达
 - 探索雷达会在「流行、摇滚、古典音乐、民谣、电子、爵士、说唱、乡村、蓝调、R&B、金属、嘻哈、轻音乐」等分类中随机挑选关键词，自动为播放列表补充新歌。
 - 如果想排除某些不喜欢的分类，可在 `js/index.js` 中的 `EXPLORE_RADAR_GENRES` 数组里删除对应条目或新增自己喜欢的分类，保存后重新部署即可生效。

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
 
 ### ☁️ Cloudflare D1 绑定与建表
 1. 在 Cloudflare Dashboard 的 **Workers & Pages → D1 → Create** 中新建数据库，建议命名为 `solara-db`（名称可自定）。
-2. 进入新建的数据库详情页，点击 **Settings → Bindings**，创建绑定：
-   - **Name** 填写 `DB`（必须与 `functions/api/storage.ts` 中的环境变量一致）。
-   - **Pages** 选择当前部署的 Pages 项目并保存。
+2. 打开 Pages 项目设置，依次进入 **Settings → Functions → Bindings → Add binding → D1 Database**：
+   - **Binding name** 填写 `DB`（必须与 `functions/api/storage.ts` 中的环境变量一致）。
+   - **D1 Database** 选择上一步创建的数据库并保存。
 3. 在数据库详情页切换到 **Query** 标签页，执行下方建表语句初始化两个独立的键值存储表（播放数据与收藏数据分离）：
    ```sql
    CREATE TABLE IF NOT EXISTS playback_store (

--- a/functions/api/storage.ts
+++ b/functions/api/storage.ts
@@ -1,0 +1,153 @@
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+type Env = {
+  DB?: D1Database;
+};
+
+type StorageData = Record<string, string | null>;
+
+type JsonBody = {
+  data?: Record<string, unknown>;
+  keys?: unknown;
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  });
+}
+
+function hasD1(env: Env): env is Required<Env> {
+  return Boolean(env.DB && typeof env.DB.prepare === "function");
+}
+
+async function ensureTable(env: Env): Promise<void> {
+  if (!hasD1(env)) {
+    return;
+  }
+  await env.DB.prepare(
+    "CREATE TABLE IF NOT EXISTS kv_store (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+  ).run();
+}
+
+async function handleGet(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  if (!hasD1(env)) {
+    return jsonResponse({ d1Available: false, data: {} });
+  }
+
+  const statusOnly = url.searchParams.get("status");
+  if (statusOnly) {
+    return jsonResponse({ d1Available: true });
+  }
+
+  const keysParam = url.searchParams.get("keys") || "";
+  const keys = keysParam
+    .split(",")
+    .map((key) => key.trim())
+    .filter(Boolean);
+
+  await ensureTable(env);
+
+  const data: StorageData = {};
+  let rows: Array<{ key: string; value: string | null }> = [];
+  if (keys.length > 0) {
+    const placeholders = keys.map(() => "?").join(",");
+    const statement = env.DB.prepare(
+      `SELECT key, value FROM kv_store WHERE key IN (${placeholders})`
+    ).bind(...keys);
+    const result = await statement.all();
+    rows = (result as any).results || result.results || [];
+    keys.forEach((key) => {
+      data[key] = null;
+    });
+  } else {
+    const result = await env.DB.prepare("SELECT key, value FROM kv_store").all();
+    rows = (result as any).results || result.results || [];
+  }
+
+  rows.forEach((row) => {
+    data[row.key] = row.value;
+  });
+
+  return jsonResponse({ d1Available: true, data });
+}
+
+async function handlePost(request: Request, env: Env): Promise<Response> {
+  if (!hasD1(env)) {
+    return jsonResponse({ d1Available: false, data: {} });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as JsonBody;
+  const payload = body.data && typeof body.data === "object" ? body.data : null;
+
+  if (!payload || Array.isArray(payload)) {
+    return jsonResponse({ error: "Invalid payload" }, 400);
+  }
+
+  const entries = Object.entries(payload).filter(([key]) => Boolean(key));
+  if (entries.length === 0) {
+    return jsonResponse({ d1Available: true, updated: 0 });
+  }
+
+  await ensureTable(env);
+
+  const statements = entries.map(([key, value]) => {
+    const storedValue = value == null ? "" : String(value);
+    return env.DB.prepare(
+      "INSERT INTO kv_store (key, value, updated_at) VALUES (?1, ?2, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at"
+    ).bind(key, storedValue);
+  });
+
+  await env.DB.batch(statements);
+  return jsonResponse({ d1Available: true, updated: entries.length });
+}
+
+async function handleDelete(request: Request, env: Env): Promise<Response> {
+  if (!hasD1(env)) {
+    return jsonResponse({ d1Available: false });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as JsonBody;
+  const keys = Array.isArray(body.keys)
+    ? body.keys.filter((key): key is string => typeof key === "string" && Boolean(key))
+    : [];
+
+  if (keys.length === 0) {
+    return jsonResponse({ d1Available: true, deleted: 0 });
+  }
+
+  await ensureTable(env);
+  const statements = keys.map((key) => env.DB.prepare("DELETE FROM kv_store WHERE key = ?1").bind(key));
+  await env.DB.batch(statements);
+  return jsonResponse({ d1Available: true, deleted: keys.length });
+}
+
+export async function onRequest(context: any): Promise<Response> {
+  const { request, env } = context;
+  const method = (request.method || "GET").toUpperCase();
+
+  if (method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: JSON_HEADERS });
+  }
+
+  if (method === "GET") {
+    return handleGet(request, env);
+  }
+
+  if (method === "POST") {
+    return handlePost(request, env);
+  }
+
+  if (method === "DELETE") {
+    return handleDelete(request, env);
+  }
+
+  return jsonResponse({ error: "Method not allowed" }, 405);
+}

--- a/functions/api/storage.ts
+++ b/functions/api/storage.ts
@@ -16,6 +16,20 @@ type JsonBody = {
   keys?: unknown;
 };
 
+const FAVORITE_KEYS = new Set([
+  "favoriteSongs",
+  "currentFavoriteIndex",
+  "favoritePlayMode",
+  "favoritePlaybackTime",
+]);
+
+const TABLES = {
+  playback: "playback_store",
+  favorites: "favorites_store",
+} as const;
+
+type TableName = (typeof TABLES)[keyof typeof TABLES];
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -27,13 +41,26 @@ function hasD1(env: Env): env is Required<Env> {
   return Boolean(env.DB && typeof env.DB.prepare === "function");
 }
 
-async function ensureTable(env: Env): Promise<void> {
+function getTableForKey(key: string): TableName {
+  if (FAVORITE_KEYS.has(key)) {
+    return TABLES.favorites;
+  }
+  return TABLES.playback;
+}
+
+async function ensureTables(env: Env): Promise<void> {
   if (!hasD1(env)) {
     return;
   }
-  await env.DB.prepare(
-    "CREATE TABLE IF NOT EXISTS kv_store (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT DEFAULT CURRENT_TIMESTAMP)"
-  ).run();
+  const createStatements = [
+    env.DB.prepare(
+      "CREATE TABLE IF NOT EXISTS playback_store (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+    ),
+    env.DB.prepare(
+      "CREATE TABLE IF NOT EXISTS favorites_store (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+    ),
+  ];
+  await env.DB.batch(createStatements);
 }
 
 async function handleGet(request: Request, env: Env): Promise<Response> {
@@ -53,26 +80,50 @@ async function handleGet(request: Request, env: Env): Promise<Response> {
     .map((key) => key.trim())
     .filter(Boolean);
 
-  await ensureTable(env);
+  await ensureTables(env);
 
   const data: StorageData = {};
   let rows: Array<{ key: string; value: string | null }> = [];
   if (keys.length > 0) {
-    const placeholders = keys.map(() => "?").join(",");
-    const statement = env.DB.prepare(
-      `SELECT key, value FROM kv_store WHERE key IN (${placeholders})`
-    ).bind(...keys);
-    const result = await statement.all();
-    rows = (result as any).results || result.results || [];
+    const groupedKeys = keys.reduce(
+      (acc, key) => {
+        const table = getTableForKey(key);
+        acc[table].push(key);
+        return acc;
+      },
+      { [TABLES.playback]: [] as string[], [TABLES.favorites]: [] as string[] }
+    );
+
+    const results: Array<{ key: string; value: string | null }> = [];
+    for (const [table, tableKeys] of Object.entries(groupedKeys)) {
+      if (tableKeys.length === 0) continue;
+      const placeholders = tableKeys.map(() => "?").join(",");
+      const statement = env.DB.prepare(
+        `SELECT key, value FROM ${table} WHERE key IN (${placeholders})`
+      ).bind(...tableKeys);
+      const result = await statement.all();
+      const rowsResult = (result as any).results || result.results || [];
+      results.push(...rowsResult);
+    }
+    rows = results;
     keys.forEach((key) => {
       data[key] = null;
     });
   } else {
-    const result = await env.DB.prepare("SELECT key, value FROM kv_store").all();
-    rows = (result as any).results || result.results || [];
+    const playbackResult = await env.DB.prepare(
+      "SELECT key, value FROM playback_store"
+    ).all();
+    const favoriteResult = await env.DB.prepare(
+      "SELECT key, value FROM favorites_store"
+    ).all();
+    rows = [
+      ...(((playbackResult as any).results || playbackResult.results || []) as any[]),
+      ...(((favoriteResult as any).results || favoriteResult.results || []) as any[]),
+    ];
   }
 
   rows.forEach((row) => {
+    if (!row || typeof row.key !== "string") return;
     data[row.key] = row.value;
   });
 
@@ -96,16 +147,31 @@ async function handlePost(request: Request, env: Env): Promise<Response> {
     return jsonResponse({ d1Available: true, updated: 0 });
   }
 
-  await ensureTable(env);
+  await ensureTables(env);
 
-  const statements = entries.map(([key, value]) => {
+  const groupedStatements: Record<string, D1PreparedStatement[]> = {
+    [TABLES.playback]: [],
+    [TABLES.favorites]: [],
+  };
+
+  entries.forEach(([key, value]) => {
     const storedValue = value == null ? "" : String(value);
-    return env.DB.prepare(
-      "INSERT INTO kv_store (key, value, updated_at) VALUES (?1, ?2, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at"
-    ).bind(key, storedValue);
+    const table = getTableForKey(key);
+    groupedStatements[table].push(
+      env.DB.prepare(
+        `INSERT INTO ${table} (key, value, updated_at) VALUES (?1, ?2, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+      ).bind(key, storedValue)
+    );
   });
 
-  await env.DB.batch(statements);
+  const batches: Promise<unknown>[] = [];
+  Object.values(groupedStatements).forEach((statements) => {
+    if (statements.length > 0) {
+      batches.push(env.DB.batch(statements));
+    }
+  });
+
+  await Promise.all(batches);
   return jsonResponse({ d1Available: true, updated: entries.length });
 }
 
@@ -123,9 +189,28 @@ async function handleDelete(request: Request, env: Env): Promise<Response> {
     return jsonResponse({ d1Available: true, deleted: 0 });
   }
 
-  await ensureTable(env);
-  const statements = keys.map((key) => env.DB.prepare("DELETE FROM kv_store WHERE key = ?1").bind(key));
-  await env.DB.batch(statements);
+  await ensureTables(env);
+
+  const groupedStatements: Record<string, D1PreparedStatement[]> = {
+    [TABLES.playback]: [],
+    [TABLES.favorites]: [],
+  };
+
+  keys.forEach((key) => {
+    const table = getTableForKey(key);
+    groupedStatements[table].push(
+      env.DB.prepare(`DELETE FROM ${table} WHERE key = ?1`).bind(key)
+    );
+  });
+
+  const batches: Promise<unknown>[] = [];
+  Object.values(groupedStatements).forEach((statements) => {
+    if (statements.length > 0) {
+      batches.push(env.DB.batch(statements));
+    }
+  });
+
+  await Promise.all(batches);
   return jsonResponse({ d1Available: true, deleted: keys.length });
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -350,6 +350,7 @@ const themeDefaults = {
 let paletteRequestId = 0;
 
 const REMOTE_STORAGE_ENDPOINT = "/api/storage";
+let remoteSyncEnabled = false;
 const STORAGE_KEYS_TO_SYNC = new Set([
     "playlistSongs",
     "currentTrackIndex",
@@ -498,7 +499,7 @@ function safeSetLocalStorage(key, value, options = {}) {
     } catch (error) {
         console.warn(`写入本地存储失败: ${key}`, error);
     }
-    if (!skipRemote && shouldSyncStorageKey(key)) {
+    if (!skipRemote && remoteSyncEnabled && shouldSyncStorageKey(key)) {
         persistStorageItems({ [key]: value });
     }
 }
@@ -510,7 +511,7 @@ function safeRemoveLocalStorage(key, options = {}) {
     } catch (error) {
         console.warn(`移除本地存储失败: ${key}`, error);
     }
-    if (!skipRemote && shouldSyncStorageKey(key)) {
+    if (!skipRemote && remoteSyncEnabled && shouldSyncStorageKey(key)) {
         removePersistentItems([key]);
     }
 }
@@ -968,6 +969,8 @@ async function bootstrapPersistentStorage() {
         applyPersistentSnapshotFromRemote(snapshot.data);
     } catch (error) {
         console.warn("加载远程存储失败", error);
+    } finally {
+        remoteSyncEnabled = true;
     }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -349,6 +349,139 @@ const themeDefaults = {
 };
 let paletteRequestId = 0;
 
+const REMOTE_STORAGE_ENDPOINT = "/api/storage";
+const STORAGE_KEYS_TO_SYNC = new Set([
+    "playlistSongs",
+    "currentTrackIndex",
+    "playMode",
+    "playbackQuality",
+    "playerVolume",
+    "currentPlaylist",
+    "currentList",
+    "currentSong",
+    "currentPlaybackTime",
+    "favoriteSongs",
+    "currentFavoriteIndex",
+    "favoritePlayMode",
+    "favoritePlaybackTime",
+    "searchSource",
+    "lastSearchState.v1",
+]);
+
+function createPersistentStorageClient() {
+    let availabilityPromise = null;
+    let remoteAvailable = false;
+
+    const checkAvailability = async () => {
+        if (availabilityPromise) {
+            return availabilityPromise;
+        }
+        availabilityPromise = (async () => {
+            try {
+                const url = new URL(REMOTE_STORAGE_ENDPOINT, window.location.origin);
+                url.searchParams.set("status", "1");
+                const response = await fetch(url.toString(), { method: "GET" });
+                if (!response.ok) {
+                    return false;
+                }
+                const result = await response.json().catch(() => ({}));
+                remoteAvailable = Boolean(result && result.d1Available);
+                return remoteAvailable;
+            } catch (error) {
+                console.warn("检查远程存储可用性失败", error);
+                return false;
+            }
+        })();
+        return availabilityPromise;
+    };
+
+    const getItems = async (keys = []) => {
+        const available = await checkAvailability();
+        if (!available || !Array.isArray(keys) || keys.length === 0) {
+            return null;
+        }
+        try {
+            const url = new URL(REMOTE_STORAGE_ENDPOINT, window.location.origin);
+            url.searchParams.set("keys", keys.join(","));
+            const response = await fetch(url.toString(), { method: "GET" });
+            if (!response.ok) {
+                return null;
+            }
+            return await response.json();
+        } catch (error) {
+            console.warn("获取远程存储数据失败", error);
+            return null;
+        }
+    };
+
+    const setItems = async (items) => {
+        const available = await checkAvailability();
+        if (!available || !items || typeof items !== "object") {
+            return false;
+        }
+        try {
+            await fetch(REMOTE_STORAGE_ENDPOINT, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ data: items }),
+            });
+            return true;
+        } catch (error) {
+            console.warn("写入远程存储失败", error);
+            return false;
+        }
+    };
+
+    const removeItems = async (keys = []) => {
+        const available = await checkAvailability();
+        if (!available || !Array.isArray(keys) || keys.length === 0) {
+            return false;
+        }
+        try {
+            await fetch(REMOTE_STORAGE_ENDPOINT, {
+                method: "DELETE",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ keys }),
+            });
+            return true;
+        } catch (error) {
+            console.warn("删除远程存储数据失败", error);
+            return false;
+        }
+    };
+
+    return {
+        checkAvailability,
+        getItems,
+        setItems,
+        removeItems,
+    };
+}
+
+const persistentStorage = createPersistentStorageClient();
+
+function shouldSyncStorageKey(key) {
+    return STORAGE_KEYS_TO_SYNC.has(key);
+}
+
+function persistStorageItems(items) {
+    if (!items || typeof items !== "object") {
+        return;
+    }
+    persistentStorage.setItems(items).catch((error) => {
+        console.warn("同步远程存储失败", error);
+    });
+}
+
+function removePersistentItems(keys = []) {
+    if (!Array.isArray(keys) || keys.length === 0) {
+        return;
+    }
+    persistentStorage.removeItems(keys).catch((error) => {
+        console.warn("移除远程存储数据失败", error);
+    });
+}
+
 function safeGetLocalStorage(key) {
     try {
         return localStorage.getItem(key);
@@ -358,19 +491,27 @@ function safeGetLocalStorage(key) {
     }
 }
 
-function safeSetLocalStorage(key, value) {
+function safeSetLocalStorage(key, value, options = {}) {
+    const { skipRemote = false } = options;
     try {
         localStorage.setItem(key, value);
     } catch (error) {
         console.warn(`写入本地存储失败: ${key}`, error);
     }
+    if (!skipRemote && shouldSyncStorageKey(key)) {
+        persistStorageItems({ [key]: value });
+    }
 }
 
-function safeRemoveLocalStorage(key) {
+function safeRemoveLocalStorage(key, options = {}) {
+    const { skipRemote = false } = options;
     try {
         localStorage.removeItem(key);
     } catch (error) {
         console.warn(`移除本地存储失败: ${key}`, error);
+    }
+    if (!skipRemote && shouldSyncStorageKey(key)) {
+        removePersistentItems([key]);
     }
 }
 
@@ -816,6 +957,188 @@ if (!Array.isArray(state.favoriteSongs) || state.favoriteSongs.length === 0) {
     state.currentFavoriteIndex = state.favoriteSongs.length - 1;
 }
 saveFavoriteState();
+
+async function bootstrapPersistentStorage() {
+    try {
+        const remoteKeys = Array.from(STORAGE_KEYS_TO_SYNC);
+        const snapshot = await persistentStorage.getItems(remoteKeys);
+        if (!snapshot || !snapshot.d1Available || !snapshot.data) {
+            return;
+        }
+        applyPersistentSnapshotFromRemote(snapshot.data);
+    } catch (error) {
+        console.warn("加载远程存储失败", error);
+    }
+}
+
+function applyPersistentSnapshotFromRemote(data) {
+    if (!data || typeof data !== "object") {
+        return;
+    }
+
+    let playlistUpdated = false;
+
+    if (typeof data.playlistSongs === "string") {
+        const playlist = parseJSON(data.playlistSongs, []);
+        if (Array.isArray(playlist)) {
+            state.playlistSongs = playlist;
+            safeSetLocalStorage("playlistSongs", data.playlistSongs, { skipRemote: true });
+            playlistUpdated = true;
+        }
+    }
+
+    if (typeof data.currentTrackIndex === "string") {
+        const index = Number.parseInt(data.currentTrackIndex, 10);
+        if (Number.isInteger(index)) {
+            state.currentTrackIndex = index;
+            safeSetLocalStorage("currentTrackIndex", data.currentTrackIndex, { skipRemote: true });
+        }
+    }
+
+    if (typeof data.playMode === "string") {
+        state.playMode = ["list", "single", "random"].includes(data.playMode) ? data.playMode : state.playMode;
+        safeSetLocalStorage("playMode", state.playMode, { skipRemote: true });
+    }
+
+    if (typeof data.playbackQuality === "string") {
+        state.playbackQuality = normalizeQuality(data.playbackQuality);
+        safeSetLocalStorage("playbackQuality", state.playbackQuality, { skipRemote: true });
+    }
+
+    if (typeof data.playerVolume === "string") {
+        const volume = Number.parseFloat(data.playerVolume);
+        if (Number.isFinite(volume)) {
+            const clamped = Math.min(Math.max(volume, 0), 1);
+            state.volume = clamped;
+            safeSetLocalStorage("playerVolume", String(clamped), { skipRemote: true });
+        }
+    }
+
+    if (typeof data.currentPlaylist === "string") {
+        state.currentPlaylist = data.currentPlaylist;
+        safeSetLocalStorage("currentPlaylist", data.currentPlaylist, { skipRemote: true });
+    }
+
+    if (typeof data.currentList === "string") {
+        state.currentList = data.currentList === "favorite" ? "favorite" : "playlist";
+        safeSetLocalStorage("currentList", state.currentList, { skipRemote: true });
+    }
+
+    if (typeof data.currentSong === "string" && data.currentSong) {
+        const currentSong = parseJSON(data.currentSong, null);
+        if (currentSong) {
+            state.currentSong = currentSong;
+            safeSetLocalStorage("currentSong", data.currentSong, { skipRemote: true });
+        }
+    }
+
+    if (typeof data.currentPlaybackTime === "string") {
+        const playbackTime = Number.parseFloat(data.currentPlaybackTime);
+        if (Number.isFinite(playbackTime) && playbackTime >= 0) {
+            state.currentPlaybackTime = playbackTime;
+            safeSetLocalStorage("currentPlaybackTime", data.currentPlaybackTime, { skipRemote: true });
+        }
+    }
+
+    if (typeof data.favoriteSongs === "string") {
+        const favorites = parseJSON(data.favoriteSongs, []);
+        if (Array.isArray(favorites)) {
+            state.favoriteSongs = favorites;
+            safeSetLocalStorage("favoriteSongs", data.favoriteSongs, { skipRemote: true });
+        }
+    }
+
+    if (typeof data.currentFavoriteIndex === "string") {
+        const favoriteIndex = Number.parseInt(data.currentFavoriteIndex, 10);
+        if (Number.isInteger(favoriteIndex)) {
+            state.currentFavoriteIndex = favoriteIndex;
+            safeSetLocalStorage("currentFavoriteIndex", data.currentFavoriteIndex, { skipRemote: true });
+        }
+    }
+
+    if (state.currentList === "favorite" && (!Array.isArray(state.favoriteSongs) || state.favoriteSongs.length === 0)) {
+        state.currentList = "playlist";
+    }
+
+    if (typeof data.favoritePlayMode === "string") {
+        state.favoritePlayMode = ["list", "single", "random"].includes(data.favoritePlayMode)
+            ? data.favoritePlayMode
+            : state.favoritePlayMode;
+        safeSetLocalStorage("favoritePlayMode", state.favoritePlayMode, { skipRemote: true });
+    }
+
+    if (typeof data.favoritePlaybackTime === "string") {
+        const favoritePlaybackTime = Number.parseFloat(data.favoritePlaybackTime);
+        if (Number.isFinite(favoritePlaybackTime) && favoritePlaybackTime >= 0) {
+            state.favoritePlaybackTime = favoritePlaybackTime;
+            safeSetLocalStorage("favoritePlaybackTime", data.favoritePlaybackTime, { skipRemote: true });
+        }
+    }
+
+    if (typeof data.searchSource === "string") {
+        state.searchSource = normalizeSource(data.searchSource);
+        safeSetLocalStorage("searchSource", state.searchSource, { skipRemote: true });
+        updateSourceLabel();
+        buildSourceMenu();
+    }
+
+    if (typeof data[LAST_SEARCH_STATE_STORAGE_KEY] === "string") {
+        const restoredSearch = parseJSON(data[LAST_SEARCH_STATE_STORAGE_KEY], null);
+        const restored = restoreStateFromSnapshot(restoredSearch);
+        if (restored) {
+            safeSetLocalStorage(LAST_SEARCH_STATE_STORAGE_KEY, data[LAST_SEARCH_STATE_STORAGE_KEY], { skipRemote: true });
+            restoreSearchResultsList();
+        }
+    }
+
+    dom.audioPlayer.volume = state.volume;
+    dom.volumeSlider.value = state.volume;
+    updateVolumeSliderBackground(state.volume);
+    updateVolumeIcon(state.volume);
+
+    renderFavorites();
+    switchLibraryTab(state.currentList === "favorite" ? "favorites" : "playlist");
+    updatePlayModeUI();
+    updateQualityLabel();
+    updatePlayPauseButton();
+
+    if (state.favoriteSongs.length === 0) {
+        state.currentFavoriteIndex = 0;
+    } else if (state.currentFavoriteIndex >= state.favoriteSongs.length) {
+        state.currentFavoriteIndex = state.favoriteSongs.length - 1;
+    }
+
+    if (playlistUpdated) {
+        let restoredIndex = state.currentTrackIndex;
+        if (!Number.isInteger(restoredIndex) || restoredIndex < 0 || restoredIndex >= state.playlistSongs.length) {
+            restoredIndex = 0;
+            state.currentTrackIndex = restoredIndex;
+        }
+        state.currentPlaylist = "playlist";
+        renderPlaylist();
+
+        const restoredSong = state.playlistSongs[restoredIndex];
+        if (restoredSong) {
+            state.currentSong = restoredSong;
+            updatePlaylistHighlight();
+            updateCurrentSongInfo(restoredSong).catch((error) => {
+                console.error("恢复远程歌曲信息失败:", error);
+            });
+        }
+    } else if (dom.playlist) {
+        dom.playlist.classList.add("empty");
+        if (dom.playlistItems) {
+            dom.playlistItems.innerHTML = "";
+        }
+    }
+
+    savePlayerState({ skipRemote: true });
+    saveFavoriteState({ skipRemote: true });
+    updatePlaylistActionStates();
+    updateMobileClearPlaylistVisibility();
+}
+
+bootstrapPersistentStorage();
 
 // ==== Media Session integration (Safari/iOS Lock Screen) ====
 (() => {
@@ -1591,27 +1914,29 @@ async function updateDynamicBackground(imageUrl) {
     }
 }
 
-function savePlayerState() {
-    safeSetLocalStorage("playlistSongs", JSON.stringify(state.playlistSongs));
-    safeSetLocalStorage("currentTrackIndex", String(state.currentTrackIndex));
-    safeSetLocalStorage("playMode", state.playMode);
-    safeSetLocalStorage("playbackQuality", state.playbackQuality);
-    safeSetLocalStorage("playerVolume", String(state.volume));
-    safeSetLocalStorage("currentPlaylist", state.currentPlaylist);
-    safeSetLocalStorage("currentList", state.currentList);
+function savePlayerState(options = {}) {
+    const { skipRemote = false } = options;
+    safeSetLocalStorage("playlistSongs", JSON.stringify(state.playlistSongs), { skipRemote });
+    safeSetLocalStorage("currentTrackIndex", String(state.currentTrackIndex), { skipRemote });
+    safeSetLocalStorage("playMode", state.playMode, { skipRemote });
+    safeSetLocalStorage("playbackQuality", state.playbackQuality, { skipRemote });
+    safeSetLocalStorage("playerVolume", String(state.volume), { skipRemote });
+    safeSetLocalStorage("currentPlaylist", state.currentPlaylist, { skipRemote });
+    safeSetLocalStorage("currentList", state.currentList, { skipRemote });
     if (state.currentSong) {
-        safeSetLocalStorage("currentSong", JSON.stringify(state.currentSong));
+        safeSetLocalStorage("currentSong", JSON.stringify(state.currentSong), { skipRemote });
     } else {
-        safeSetLocalStorage("currentSong", "");
+        safeSetLocalStorage("currentSong", "", { skipRemote });
     }
-    safeSetLocalStorage("currentPlaybackTime", String(state.currentPlaybackTime || 0));
+    safeSetLocalStorage("currentPlaybackTime", String(state.currentPlaybackTime || 0), { skipRemote });
 }
 
-function saveFavoriteState() {
-    safeSetLocalStorage("favoriteSongs", JSON.stringify(state.favoriteSongs));
-    safeSetLocalStorage("currentFavoriteIndex", String(state.currentFavoriteIndex));
-    safeSetLocalStorage("favoritePlayMode", state.favoritePlayMode);
-    safeSetLocalStorage("favoritePlaybackTime", String(state.favoritePlaybackTime || 0));
+function saveFavoriteState(options = {}) {
+    const { skipRemote = false } = options;
+    safeSetLocalStorage("favoriteSongs", JSON.stringify(state.favoriteSongs), { skipRemote });
+    safeSetLocalStorage("currentFavoriteIndex", String(state.currentFavoriteIndex), { skipRemote });
+    safeSetLocalStorage("favoritePlayMode", state.favoritePlayMode, { skipRemote });
+    safeSetLocalStorage("favoritePlaybackTime", String(state.favoritePlaybackTime || 0), { skipRemote });
 }
 
 // 调试日志函数


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages Function for D1-backed key-value persistence
- sync playlist and favorites state to D1 while preserving localStorage fallback
- load remote state into the player UI when a bound D1 database is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a7cb9e1a88330b619ed6580d2e778)